### PR TITLE
JW Calendar Page

### DIFF
--- a/CS Project Manager/Models/CalendarItem.cs
+++ b/CS Project Manager/Models/CalendarItem.cs
@@ -1,0 +1,22 @@
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using System.ComponentModel.DataAnnotations;
+
+namespace CS_Project_Manager.Models
+{
+    public class CalendarItem
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public ObjectId Id { get; set; }
+
+        [Required]
+        public required string EventName { get; set; }
+        public DateTime StartDateTime { get; set; }
+        public DateTime EndDateTime { get; set; }
+
+        [BsonElement("AssocTeamId")]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public ObjectId AssocTeamId { get; set; }
+    }
+}

--- a/CS Project Manager/Models/UserAvailability.cs
+++ b/CS Project Manager/Models/UserAvailability.cs
@@ -12,8 +12,8 @@ namespace CS_Project_Manager.Models
         public required string Day { get; set; }
         public required string Time { get; set; }
 
-        [BsonElement("AssocTeamId")]
+        [BsonElement("AssocUserId")]
         [BsonRepresentation(BsonType.ObjectId)]
-        public ObjectId AssocTeamId { get; set; }
+        public ObjectId AssocUserId { get; set; }
     }
 }

--- a/CS Project Manager/Models/UserAvailability.cs
+++ b/CS Project Manager/Models/UserAvailability.cs
@@ -1,0 +1,19 @@
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace CS_Project_Manager.Models
+{
+    public class UserAvailability
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public ObjectId Id { get; set; }
+
+        public required string Day { get; set; }
+        public required string Time { get; set; }
+
+        [BsonElement("AssocTeamId")]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public ObjectId AssocTeamId { get; set; }
+    }
+}

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -1,0 +1,19 @@
+@page
+@model CalendarModel
+@{
+    ViewData["Title"] = "Calendar";
+}
+
+<h2>Calendar</h2>
+
+<!-- Displaying user login status -->
+<div class="navbar-text">
+    @if (User.Identity?.IsAuthenticated == true)
+    {
+        <span>Hello, @User.Identity.Name!</span>
+    }
+    else
+    {
+        <span>Not logged in</span>
+    }
+</div>

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -12,9 +12,16 @@
         *display: inline;
         zoom: 1;
         width: 60px;
-        height: 30px;
+        height: 20px;
         background: #ffffff;
         text-align:center;
+    }
+
+    .legend {
+        width: 20px;
+        height: 20px;
+        border: 1px black solid;
+        display: inline-block;
     }
 </style>
 
@@ -32,7 +39,7 @@
                         <div class="calendar-box"></div>
                         @foreach (var day in Model.Days)
                         {
-                            <div class="calendar-box" style="font-size:16px;">@day</div>
+                            <div class="calendar-box" style="font-size:16px;height: 30px">@day</div>
                         }
                     </div>
                     @foreach (var time in Model.Times)
@@ -55,6 +62,13 @@
                         </div>
                     }
                 </div>
+                <br>
+                <br>
+                <div class="calendar-box"></div>
+                <div class="legend" style="background: #000000;"></div>
+                <div style="display:inline-block;font-size:16px;">Unavailable</div>
+                <div class="legend" style="background: #ffffff;"></div>
+                <div style="display:inline-block;font-size:16px;">Available</div>
             </div>
 
             <div class="col-md-6">

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -42,8 +42,15 @@
                             <div class="calendar-box" style="font-size:12px;">@time</div>
                             @foreach (var day in Model.Days)
                             {
-                                <div class="calendar-box" style="border: 1px black solid;"></div>
-                            }
+                                @if (Model.UserAvailabilityItems.Any(u => u.Day == day && u.Time == time))
+                                {
+                                    <div class="calendar-box" style="border: 1px black solid;background: #000000"></div>
+                                } else
+                                {
+                                    <div class="calendar-box" style="border: 1px black solid;"></div>
+                                }
+
+                    }
                         </div>
                     }
                 </div>

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -4,32 +4,63 @@
     ViewData["Title"] = "Calendar";
 }
 
-<h2>Calendar</h2>
+<style>
+    .calendar-box {
+        vertical-align: top;
+        font-size: 0px;
+        display: inline-block;
+        *display: inline;
+        zoom: 1;
+        width: 60px;
+        height: 30px;
+        background: #ffffff;
+        text-align:center;
+    }
+</style>
+
+<h2>Calendar and Events</h2>
 
 <!-- Displaying user login status -->
 <div class="navbar-text">
     @if (User.Identity?.IsAuthenticated == true)
     {
         <br>
-        <div id="Calendar" style="left:0%;display:inline-block;white-space:nowrap;">
-            <div style ="font-size:0px;vertical-align:top;">
-                <div style="vertical-align:top;display:inline-block;*display:inline;zoom:1;width:60px;height:30px;font-size:0px;background: #ffffff;"></div>
-                @foreach (var day in Model.Days)
-                {
-                    <div style="text-align:center;line-height:30px;vertical-align:top;display:inline-block;*display:inline;zoom:1;width:60px;height:30px;font-size:16px;background: #ffffff;">@day</div>
-                }
-            </div>
-            @foreach (var time in Model.Times)
-            {
-                
-                <div style="font-size:0px;vertical-align:top;">
-                    <div style="text-align:center;vertical-align:top;display:inline-block;*display:inline;zoom:1;width:60px;height:30px;font-size:14px;background: #ffffff;">@time</div>
-                    @foreach (var day in Model.Days)
+        <div class="row">
+            <div class="col-md-6">
+                <h2>Calendar</h2>
+                <div style="display:inline-block;white-space:nowrap;">
+                    <div style ="font-size:0px;vertical-align:top;">
+                        <div class="calendar-box"></div>
+                        @foreach (var day in Model.Days)
+                        {
+                            <div class="calendar-box" style="font-size:16px;">@day</div>
+                        }
+                    </div>
+                    @foreach (var time in Model.Times)
                     {
-                        <div style="vertical-align:top;display:inline-block;*display:inline;zoom:1;width:60px;height:30px;font-size:0px;border: 1px black solid;background: #ffffff;"></div>
+                
+                        <div style="font-size:0px;vertical-align:top;">
+                            <div class="calendar-box" style="font-size:12px;">@time</div>
+                            @foreach (var day in Model.Days)
+                            {
+                                <div class="calendar-box" style="border: 1px black solid;"></div>
+                            }
+                        </div>
                     }
                 </div>
-            }
+            </div>
+
+            <div class="col-md-6">
+                <h2>Event List</h2>
+                <div id="EventList">
+                    <ul>
+                        @foreach (var item in Model.TeamCalendarItems)
+                        {
+                            <li>@item.EventName: @item.StartDateTime.ToString()</li>
+                        }
+                    </ul>
+                </div>
+            </div>
         </div>
     }
     else

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -18,16 +18,15 @@
     }
 </style>
 
-<h2>Calendar and Events</h2>
+<h2>Team Calendar and Events</h2>
 
-<!-- Displaying user login status -->
 <div class="navbar-text">
     @if (User.Identity?.IsAuthenticated == true)
     {
         <br>
         <div class="row">
             <div class="col-md-6">
-                <h2>Calendar</h2>
+                <h2>Availability Calendar</h2>
                 <div style="display:inline-block;white-space:nowrap;">
                     <div style ="font-size:0px;vertical-align:top;">
                         <div class="calendar-box"></div>

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -10,7 +10,27 @@
 <div class="navbar-text">
     @if (User.Identity?.IsAuthenticated == true)
     {
-        <span>Hello, @User.Identity.Name!</span>
+        <br>
+        <div id="Calendar" style="left:0%;display:inline-block;white-space:nowrap;">
+            <div style ="font-size:0px;vertical-align:top;">
+                <div style="vertical-align:top;display:inline-block;*display:inline;zoom:1;width:60px;height:30px;font-size:0px;background: #ffffff;"></div>
+                @foreach (var day in Model.Days)
+                {
+                    <div style="text-align:center;line-height:30px;vertical-align:top;display:inline-block;*display:inline;zoom:1;width:60px;height:30px;font-size:16px;background: #ffffff;">@day</div>
+                }
+            </div>
+            @foreach (var time in Model.Times)
+            {
+                
+                <div style="font-size:0px;vertical-align:top;">
+                    <div style="text-align:center;vertical-align:top;display:inline-block;*display:inline;zoom:1;width:60px;height:30px;font-size:14px;background: #ffffff;">@time</div>
+                    @foreach (var day in Model.Days)
+                    {
+                        <div style="vertical-align:top;display:inline-block;*display:inline;zoom:1;width:60px;height:30px;font-size:0px;border: 1px black solid;background: #ffffff;"></div>
+                    }
+                </div>
+            }
+        </div>
     }
     else
     {

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -45,7 +45,8 @@
                                 @if (Model.UserAvailabilityItems.Any(u => u.Day == day && u.Time == time))
                                 {
                                     <div class="calendar-box" style="border: 1px black solid;background: #000000"></div>
-                                } else
+                                }
+                                else
                                 {
                                     <div class="calendar-box" style="border: 1px black solid;"></div>
                                 }
@@ -59,12 +60,20 @@
             <div class="col-md-6">
                 <h2>Event List</h2>
                 <div id="EventList">
-                    <ul>
-                        @foreach (var item in Model.TeamCalendarItems)
-                        {
-                            <li>@item.EventName: @item.StartDateTime.ToString()</li>
-                        }
-                    </ul>
+                    @if (Model.TeamCalendarItems.Count > 0)
+                    {
+                        <ul>
+                            @foreach (var item in Model.TeamCalendarItems)
+                            {
+                                <li>@item.EventName: @item.StartDateTime.ToString()</li>
+                            }
+                        </ul>
+                    }
+                    else
+                    {
+                        <p>No scheduled events!</p>
+                    }
+
                 </div>
             </div>
         </div>

--- a/CS Project Manager/Pages/Calendar.cshtml.cs
+++ b/CS Project Manager/Pages/Calendar.cshtml.cs
@@ -4,8 +4,8 @@ Created By: Jackson Wunderlich
 Date Created: 3/24/25
 Last Revised By: Jackson Wunderlich
 Date Revised: 3/24/25
-Purpose: 
-Preconditions: 
+Purpose: page displaying a calendar that allows users to set and view availability and create meetings
+Preconditions: MongoDBService, other service instances properly initialized and injected; CalendarItem must be correctly defined
 Error and exceptions: ArgumentNullException: username is null or empty; MongoException: issue with the MongoDB connection or operation; InvalidOperationException: data cannot be retrieved
 Side effects: N/A
 Other faults: N/A
@@ -15,6 +15,7 @@ using CS_Project_Manager.Models;
 using CS_Project_Manager.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using MongoDB.Bson;
 using System.Security.Claims;
 
 namespace CS_Project_Manager.Pages
@@ -23,27 +24,31 @@ namespace CS_Project_Manager.Pages
     {
         private readonly TeamService _teamService;
         private readonly StudentUserService _userService;
+        private readonly CalendarService _calendarService;
 
         // bound property for list of teams
         [BindProperty]
-        public List<Team> Teams { get; set; }
+        public Team ProjectTeam { get; set; }
+
+        public List<String> Days { get; set; }
+        public List<String> Times { get; set; }
 
         private readonly ILogger<DashboardModel> _logger;
 
-        public CalendarModel(ILogger<DashboardModel> logger, TeamService teamService, StudentUserService userService)
+        public CalendarModel(ILogger<DashboardModel> logger, TeamService teamService, StudentUserService userService, CalendarService calendarService)
         {
             _logger = logger;
             _teamService = teamService;
             _userService = userService;
-            Teams = new List<Team>();
+            _calendarService = calendarService;
+            Days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+            Times = ["9:00", "9:30", "10:00", "10:30", "11:00", "11:30", "12:00", "12:30", "1:00", "1:30", "2:00", "2:30", "3:00", "3:30", "4:00", "4:30", "5:00", "5:30", "6:00"];
         }
 
-        public async Task OnGetAsync()
+        public async Task OnGetAsync(ObjectId projectId)
         {
-            // gets a list of all teams related to the user
-            var username = User.FindFirstValue(ClaimTypes.Name);
-            var userObj = await _userService.GetUserByUsernameAsync(username);
-            Teams = await _teamService.GetTeamsByStudentIdAsync(userObj.Id);
+            // gets the team related to the current project
+            ProjectTeam = await _teamService.GetTeamByProjectIdAsync(projectId);
         }
     }
 }

--- a/CS Project Manager/Pages/Calendar.cshtml.cs
+++ b/CS Project Manager/Pages/Calendar.cshtml.cs
@@ -3,7 +3,7 @@
 Created By: Jackson Wunderlich
 Date Created: 3/24/25
 Last Revised By: Jackson Wunderlich
-Date Revised: 3/24/25
+Date Revised: 3/26/25
 Purpose: page displaying a calendar that allows users to set and view availability and create meetings
 Preconditions: MongoDBService, other service instances properly initialized and injected; CalendarItem must be correctly defined
 Error and exceptions: ArgumentNullException: username is null or empty; MongoException: issue with the MongoDB connection or operation; InvalidOperationException: data cannot be retrieved
@@ -25,9 +25,10 @@ namespace CS_Project_Manager.Pages
         private readonly StudentUserService _userService;
         private readonly CalendarService _calendarService;
 
-        // bound property for list of teams
+        // bound property for the team related to the project
         [BindProperty]
         public Team ProjectTeam { get; set; }
+        // bound property for the list of calendar events related to the team
         [BindProperty]
         public List<CalendarItem> TeamCalendarItems { get; set; }
 
@@ -42,13 +43,14 @@ namespace CS_Project_Manager.Pages
             _teamService = teamService;
             _userService = userService;
             _calendarService = calendarService;
+            // creates lists of days and times for the calendar
             Days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
             Times = ["9:00", "9:30", "10:00", "10:30", "11:00", "11:30", "12:00", "12:30", "1:00", "1:30", "2:00", "2:30", "3:00", "3:30", "4:00", "4:30", "5:00", "5:30"];
         }
 
         public async Task OnGetAsync(ObjectId teamId)
         {
-            // gets the team related to the current project
+            // gets the team related to the current project and a list of all calendar items for that team
             ProjectTeam = await _teamService.GetTeamByIdAsync(teamId);
             TeamCalendarItems = await _calendarService.GetCalendarItemsByTeamIdAsync(ProjectTeam.Id);
         }

--- a/CS Project Manager/Pages/Calendar.cshtml.cs
+++ b/CS Project Manager/Pages/Calendar.cshtml.cs
@@ -1,0 +1,49 @@
+/*
+* Prologue
+Created By: Jackson Wunderlich
+Date Created: 3/24/25
+Last Revised By: Jackson Wunderlich
+Date Revised: 3/24/25
+Purpose: 
+Preconditions: 
+Error and exceptions: ArgumentNullException: username is null or empty; MongoException: issue with the MongoDB connection or operation; InvalidOperationException: data cannot be retrieved
+Side effects: N/A
+Other faults: N/A
+*/
+
+using CS_Project_Manager.Models;
+using CS_Project_Manager.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Security.Claims;
+
+namespace CS_Project_Manager.Pages
+{
+    public class CalendarModel : PageModel
+    {
+        private readonly TeamService _teamService;
+        private readonly StudentUserService _userService;
+
+        // bound property for list of teams
+        [BindProperty]
+        public List<Team> Teams { get; set; }
+
+        private readonly ILogger<DashboardModel> _logger;
+
+        public CalendarModel(ILogger<DashboardModel> logger, TeamService teamService, StudentUserService userService)
+        {
+            _logger = logger;
+            _teamService = teamService;
+            _userService = userService;
+            Teams = new List<Team>();
+        }
+
+        public async Task OnGetAsync()
+        {
+            // gets a list of all teams related to the user
+            var username = User.FindFirstValue(ClaimTypes.Name);
+            var userObj = await _userService.GetUserByUsernameAsync(username);
+            Teams = await _teamService.GetTeamsByStudentIdAsync(userObj.Id);
+        }
+    }
+}

--- a/CS Project Manager/Pages/Calendar.cshtml.cs
+++ b/CS Project Manager/Pages/Calendar.cshtml.cs
@@ -3,7 +3,7 @@
 Created By: Jackson Wunderlich
 Date Created: 3/24/25
 Last Revised By: Jackson Wunderlich
-Date Revised: 3/26/25
+Date Revised: 3/27/25
 Purpose: page displaying a calendar that allows users to set and view availability and create meetings
 Preconditions: MongoDBService, other service instances properly initialized and injected; CalendarItem must be correctly defined
 Error and exceptions: ArgumentNullException: username is null or empty; MongoException: issue with the MongoDB connection or operation; InvalidOperationException: data cannot be retrieved
@@ -16,6 +16,7 @@ using CS_Project_Manager.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using MongoDB.Bson;
+using System.Linq;
 
 namespace CS_Project_Manager.Pages
 {
@@ -28,9 +29,14 @@ namespace CS_Project_Manager.Pages
         // bound property for the team related to the project
         [BindProperty]
         public Team ProjectTeam { get; set; }
+
         // bound property for the list of calendar events related to the team
         [BindProperty]
         public List<CalendarItem> TeamCalendarItems { get; set; }
+
+        // bound property for the list of user availability items related to the team
+        [BindProperty]
+        public List<UserAvailability> UserAvailabilityItems { get; set; }
 
         public List<String> Days { get; set; }
         public List<String> Times { get; set; }
@@ -50,9 +56,12 @@ namespace CS_Project_Manager.Pages
 
         public async Task OnGetAsync(ObjectId teamId)
         {
-            // gets the team related to the current project and a list of all calendar items for that team
+            // gets the team related to the current project
             ProjectTeam = await _teamService.GetTeamByIdAsync(teamId);
+            // gets a list of all calendar items for the team
             TeamCalendarItems = await _calendarService.GetCalendarItemsByTeamIdAsync(ProjectTeam.Id);
+            // gets a list of all user availability items for the team
+            UserAvailabilityItems = await _calendarService.GetUserAvailabilityByTeamIdAsync(ProjectTeam.Id);
         }
     }
 }

--- a/CS Project Manager/Pages/Calendar.cshtml.cs
+++ b/CS Project Manager/Pages/Calendar.cshtml.cs
@@ -16,7 +16,6 @@ using CS_Project_Manager.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using MongoDB.Bson;
-using System.Security.Claims;
 
 namespace CS_Project_Manager.Pages
 {
@@ -29,6 +28,8 @@ namespace CS_Project_Manager.Pages
         // bound property for list of teams
         [BindProperty]
         public Team ProjectTeam { get; set; }
+        [BindProperty]
+        public List<CalendarItem> TeamCalendarItems { get; set; }
 
         public List<String> Days { get; set; }
         public List<String> Times { get; set; }
@@ -42,13 +43,14 @@ namespace CS_Project_Manager.Pages
             _userService = userService;
             _calendarService = calendarService;
             Days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-            Times = ["9:00", "9:30", "10:00", "10:30", "11:00", "11:30", "12:00", "12:30", "1:00", "1:30", "2:00", "2:30", "3:00", "3:30", "4:00", "4:30", "5:00", "5:30", "6:00"];
+            Times = ["9:00", "9:30", "10:00", "10:30", "11:00", "11:30", "12:00", "12:30", "1:00", "1:30", "2:00", "2:30", "3:00", "3:30", "4:00", "4:30", "5:00", "5:30"];
         }
 
-        public async Task OnGetAsync(ObjectId projectId)
+        public async Task OnGetAsync(ObjectId teamId)
         {
             // gets the team related to the current project
-            ProjectTeam = await _teamService.GetTeamByProjectIdAsync(projectId);
+            ProjectTeam = await _teamService.GetTeamByIdAsync(teamId);
+            TeamCalendarItems = await _calendarService.GetCalendarItemsByTeamIdAsync(ProjectTeam.Id);
         }
     }
 }

--- a/CS Project Manager/Pages/Calendar.cshtml.cs
+++ b/CS Project Manager/Pages/Calendar.cshtml.cs
@@ -3,7 +3,7 @@
 Created By: Jackson Wunderlich
 Date Created: 3/24/25
 Last Revised By: Jackson Wunderlich
-Date Revised: 3/27/25
+Date Revised: 3/28/25
 Purpose: page displaying a calendar that allows users to set and view availability and create meetings
 Preconditions: MongoDBService, other service instances properly initialized and injected; CalendarItem must be correctly defined
 Error and exceptions: ArgumentNullException: username is null or empty; MongoException: issue with the MongoDB connection or operation; InvalidOperationException: data cannot be retrieved
@@ -49,9 +49,11 @@ namespace CS_Project_Manager.Pages
             _teamService = teamService;
             _userService = userService;
             _calendarService = calendarService;
+            UserAvailabilityItems = new List<UserAvailability>();
             // creates lists of days and times for the calendar
             Days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-            Times = ["9:00", "9:30", "10:00", "10:30", "11:00", "11:30", "12:00", "12:30", "1:00", "1:30", "2:00", "2:30", "3:00", "3:30", "4:00", "4:30", "5:00", "5:30"];
+            Times = ["8:00", "8:30", "9:00", "9:30", "10:00", "10:30", "11:00", "11:30", "12:00", "12:30", "1:00", "1:30", "2:00",
+                     "2:30", "3:00", "3:30", "4:00", "4:30", "5:00", "5:30", "6:00", "6:30", "7:00", "7:30", "8:00", "8:30"];
         }
 
         public async Task OnGetAsync(ObjectId teamId)
@@ -61,7 +63,15 @@ namespace CS_Project_Manager.Pages
             // gets a list of all calendar items for the team
             TeamCalendarItems = await _calendarService.GetCalendarItemsByTeamIdAsync(ProjectTeam.Id);
             // gets a list of all user availability items for the team
-            UserAvailabilityItems = await _calendarService.GetUserAvailabilityByTeamIdAsync(ProjectTeam.Id);
+            foreach (var user in ProjectTeam.Members)
+            {
+                var newItems = await _calendarService.GetUserAvailabilityByUserIdAsync(user);
+                foreach (var item in newItems)
+                {
+                    UserAvailabilityItems.Add(item);
+                }
+            }
+            
         }
     }
 }

--- a/CS Project Manager/Pages/Dashboard.cshtml
+++ b/CS Project Manager/Pages/Dashboard.cshtml
@@ -50,10 +50,6 @@
             <button type="submit" class="btn btn-primary">To-do Lists</button>
         </form>
         <br />
-        <form method="get" asp-page="/Calendar">
-            <button type="submit" class="btn btn-primary">Calendar</button>
-        </form>
-        <br />
     }
     else
     {

--- a/CS Project Manager/Pages/Dashboard.cshtml
+++ b/CS Project Manager/Pages/Dashboard.cshtml
@@ -50,6 +50,10 @@
             <button type="submit" class="btn btn-primary">To-do Lists</button>
         </form>
         <br />
+        <form method="get" asp-page="/Account">
+            <button type="submit" class="btn btn-primary">Account</button>
+        </form>
+        <br />
     }
     else
     {

--- a/CS Project Manager/Pages/Dashboard.cshtml
+++ b/CS Project Manager/Pages/Dashboard.cshtml
@@ -50,6 +50,10 @@
             <button type="submit" class="btn btn-primary">To-do Lists</button>
         </form>
         <br />
+        <form method="get" asp-page="/Calendar">
+            <button type="submit" class="btn btn-primary">Calendar</button>
+        </form>
+        <br />
     }
     else
     {

--- a/CS Project Manager/Pages/Dashboard.cshtml.cs
+++ b/CS Project Manager/Pages/Dashboard.cshtml.cs
@@ -49,16 +49,20 @@ namespace CS_Project_Manager.Pages
 
         public async Task OnGetAsync()
         {
-            // gets a list of all projects related to the user
-            var username = User.FindFirstValue(ClaimTypes.Name);
-            var userObj = await _userService.GetUserByUsernameAsync(username);
-            Teams = await _teamService.GetTeamsByStudentIdAsync(userObj.Id);
-            foreach (var team in Teams)
+            // check for user login
+            if (User.Identity?.IsAuthenticated == true)
             {
-                var projects = await _projectService.GetProjectsByTeamIdAsync(team.Id);
-                foreach (var project in projects)
+                // gets a list of all projects related to the user
+                var username = User.FindFirstValue(ClaimTypes.Name);
+                var userObj = await _userService.GetUserByUsernameAsync(username);
+                Teams = await _teamService.GetTeamsByStudentIdAsync(userObj.Id);
+                foreach (var team in Teams)
                 {
-                    Projects.Add(project);
+                    var projects = await _projectService.GetProjectsByTeamIdAsync(team.Id);
+                    foreach (var project in projects)
+                    {
+                        Projects.Add(project);
+                    }
                 }
             }
         }

--- a/CS Project Manager/Pages/RequirementsStack.cshtml
+++ b/CS Project Manager/Pages/RequirementsStack.cshtml
@@ -49,7 +49,7 @@
 </form>
 
 <hr>
-<div style="display: flex; gap: 10px;"
+<div style="display: flex; gap: 10px;">
 <form method="post">
     <input type="hidden" name="projectId" value="@Model.ProjectId" />
     <button type="submit" asp-page-handler="Export" class="btn btn-primary">Export to Excel</button>
@@ -61,7 +61,7 @@
 </form>
 
 <form method="get" asp-page="/Calendar">
-    <input type="hidden" name="projectId" value="@Model.ProjectId" />
+    <input type="hidden" name="teamId" value="@Model.AssocTeamId" />
     <button type="submit" class="btn btn-primary">Calendar</button>
 </form>
 </div>

--- a/CS Project Manager/Pages/RequirementsStack.cshtml
+++ b/CS Project Manager/Pages/RequirementsStack.cshtml
@@ -59,6 +59,11 @@
     <input type="hidden" name="projectId" value="@Model.ProjectId" />
     <button type="submit" class="btn btn-primary">Brainstorming</button>
 </form>
+
+<form method="get" asp-page="/Calendar">
+    <input type="hidden" name="projectId" value="@Model.ProjectId" />
+    <button type="submit" class="btn btn-primary">Calendar</button>
+</form>
 </div>
 
 <h3>Added Requirements</h3>

--- a/CS Project Manager/Pages/RequirementsStack.cshtml.cs
+++ b/CS Project Manager/Pages/RequirementsStack.cshtml.cs
@@ -44,6 +44,8 @@ namespace CS_Project_Manager.Pages
 
         [BindProperty(SupportsGet = true)]
         public ObjectId ProjectId { get; set; }
+        [BindProperty(SupportsGet = true)]
+        public ObjectId AssocTeamId { get; set; }
         public List<StudentUser> TeamMembers = new List<StudentUser>();      
         public RequirementsStackModel(RequirementService requirementService, ProjectService projectService, TeamService teamService, StudentUserService studentUserService)
         {
@@ -68,6 +70,7 @@ namespace CS_Project_Manager.Pages
 
             var currentProject = await _projectService.GetProjectById(ProjectId);
             var curTeam = await _teamService.GetTeamByIdAsync(currentProject.AssociatedTeam);
+            AssocTeamId = currentProject.AssociatedTeam;
 
             TeamMembers = (await Task.WhenAll(curTeam.Members
                 .Select(member => _studentUserService.GetUserByIdAsync(member)))).ToList();

--- a/CS Project Manager/Program.cs
+++ b/CS Project Manager/Program.cs
@@ -2,7 +2,7 @@
  * Prologue: Program.cs
  * Programmers: Anakha Krishna, Ginny Ke, Jackson Wunderlich
  * Date Created: 2/13/25
- * Date Revised: 3/16/25 - AK
+ * Date Revised: 3/24/25 - JW
  * Purpose: Configures and starts the web application using ASP.NET Core with Razor Pages.
  *
  * Preconditions:
@@ -72,6 +72,7 @@ builder.Services.AddScoped<ProjectService>();
 builder.Services.AddScoped<RequirementService>();
 builder.Services.AddScoped<TodoService>();
 builder.Services.AddScoped<BrainstormService>();
+builder.Services.AddScoped<CalendarService>();
 
 var app = builder.Build(); // Build app from configured builder
 

--- a/CS Project Manager/Services/CalendarService.cs
+++ b/CS Project Manager/Services/CalendarService.cs
@@ -3,7 +3,7 @@
 Created By: Jackson Wunderlich
 Date Created: 3/24/25
 Last Revised By: Jackson Wunderlich
-Date Revised: 3/24/25
+Date Revised: 3/26/25
 Purpose: Provides data access methods for calendar operations in the database
 Preconditions: MongoDB setup, CalendarItems table exists, CalendarItem model defined
 Postconditions: new CalendarItem items can be added, items can be updated and removed

--- a/CS Project Manager/Services/CalendarService.cs
+++ b/CS Project Manager/Services/CalendarService.cs
@@ -1,0 +1,47 @@
+/*
+* Prologue
+Created By: Jackson Wunderlich
+Date Created: 3/24/25
+Last Revised By: Jackson Wunderlich
+Date Revised: 3/24/25
+Purpose: Provides data access methods for calendar operations in the database
+Preconditions: MongoDB setup, CalendarItems table exists, CalendarItem model defined
+Postconditions: new CalendarItem items can be added, items can be updated and removed
+Error and exceptions: MongoDB.Driver.MongoException (thrown if there is an issue with the MongoDB connection or operations)
+Side effects: N/A
+Invariants: _calendarItems collection is always initialized with the "CalendarItems" collection from the MongoDB database
+Other faults: N/A
+*/
+
+using CS_Project_Manager.Models;
+using MongoDB.Driver;
+using MongoDB.Bson;
+
+namespace CS_Project_Manager.Services
+{
+    public class CalendarService
+    {
+        private readonly IMongoCollection<CalendarItem> _calendarItems;
+
+        public CalendarService(MongoDBService mongoDBService)
+        {
+            _calendarItems = mongoDBService.GetCollection<CalendarItem>("CalendarItems");
+        }
+
+        // Adds a new calendar item
+        public async Task AddCalendarItemAsync(CalendarItem newCalendarItem) =>
+            await _calendarItems.InsertOneAsync(newCalendarItem);
+
+        // Gets a calendar item by its ObjectId
+        public async Task<CalendarItem?> GetCalendarItemByIdAsync(ObjectId id) =>
+            await _calendarItems.Find(c => c.Id == id).FirstOrDefaultAsync();
+
+        // Gets all calendar items associated with a project by team ID
+        public async Task<List<CalendarItem>> GetTodoByTeamIdAsync(ObjectId userId) =>
+            await _calendarItems.Find(c => c.AssocTeamId == userId).ToListAsync();
+
+        // Removes a calendar item by its ObjectId
+        public async Task RemoveCalendarItemAsync(ObjectId id) =>
+            await _calendarItems.DeleteOneAsync(c => c.Id == id);
+    }
+}

--- a/CS Project Manager/Services/CalendarService.cs
+++ b/CS Project Manager/Services/CalendarService.cs
@@ -3,7 +3,7 @@
 Created By: Jackson Wunderlich
 Date Created: 3/24/25
 Last Revised By: Jackson Wunderlich
-Date Revised: 3/26/25
+Date Revised: 3/27/25
 Purpose: Provides data access methods for calendar operations in the database
 Preconditions: MongoDB setup, CalendarItems table exists, CalendarItem model defined
 Postconditions: new CalendarItem items can be added, items can be updated and removed
@@ -22,10 +22,12 @@ namespace CS_Project_Manager.Services
     public class CalendarService
     {
         private readonly IMongoCollection<CalendarItem> _calendarItems;
+        private readonly IMongoCollection<UserAvailability> _userAvailability;
 
         public CalendarService(MongoDBService mongoDBService)
         {
             _calendarItems = mongoDBService.GetCollection<CalendarItem>("CalendarItems");
+            _userAvailability = mongoDBService.GetCollection<UserAvailability>("UserAvailabilityItems");
         }
 
         // Adds a new calendar item
@@ -43,5 +45,13 @@ namespace CS_Project_Manager.Services
         // Removes a calendar item by its ObjectId
         public async Task RemoveCalendarItemAsync(ObjectId id) =>
             await _calendarItems.DeleteOneAsync(c => c.Id == id);
+
+        // gets a user availability item by its ID
+        public async Task GetUserAvailabilityByIdAsync(ObjectId id) =>
+            await _userAvailability.Find(u => u.Id == id).FirstOrDefaultAsync();
+
+        // gets user availability items by their team ID
+        public async Task<List<UserAvailability>> GetUserAvailabilityByTeamIdAsync(ObjectId teamId) =>
+            await _userAvailability.Find(u => u.AssocTeamId == teamId).ToListAsync();
     }
 }

--- a/CS Project Manager/Services/CalendarService.cs
+++ b/CS Project Manager/Services/CalendarService.cs
@@ -3,7 +3,7 @@
 Created By: Jackson Wunderlich
 Date Created: 3/24/25
 Last Revised By: Jackson Wunderlich
-Date Revised: 3/27/25
+Date Revised: 3/28/25
 Purpose: Provides data access methods for calendar operations in the database
 Preconditions: MongoDB setup, CalendarItems table exists, CalendarItem model defined
 Postconditions: new CalendarItem items can be added, items can be updated and removed
@@ -51,7 +51,7 @@ namespace CS_Project_Manager.Services
             await _userAvailability.Find(u => u.Id == id).FirstOrDefaultAsync();
 
         // gets user availability items by their team ID
-        public async Task<List<UserAvailability>> GetUserAvailabilityByTeamIdAsync(ObjectId teamId) =>
-            await _userAvailability.Find(u => u.AssocTeamId == teamId).ToListAsync();
+        public async Task<List<UserAvailability>> GetUserAvailabilityByUserIdAsync(ObjectId userId) =>
+            await _userAvailability.Find(u => u.AssocUserId == userId).ToListAsync();
     }
 }

--- a/CS Project Manager/Services/CalendarService.cs
+++ b/CS Project Manager/Services/CalendarService.cs
@@ -37,8 +37,8 @@ namespace CS_Project_Manager.Services
             await _calendarItems.Find(c => c.Id == id).FirstOrDefaultAsync();
 
         // Gets all calendar items associated with a project by team ID
-        public async Task<List<CalendarItem>> GetTodoByTeamIdAsync(ObjectId userId) =>
-            await _calendarItems.Find(c => c.AssocTeamId == userId).ToListAsync();
+        public async Task<List<CalendarItem>> GetCalendarItemsByTeamIdAsync(ObjectId teamId) =>
+            await _calendarItems.Find(c => c.AssocTeamId == teamId).ToListAsync();
 
         // Removes a calendar item by its ObjectId
         public async Task RemoveCalendarItemAsync(ObjectId id) =>

--- a/CS Project Manager/Services/MongoDBService.cs
+++ b/CS Project Manager/Services/MongoDBService.cs
@@ -11,7 +11,8 @@ Error and exceptions: MongoDB.Driver.MongoConfigurationException (thrown if the 
 Side effects: N/A
 Invariants: client field is always initialized with a valid MongoClient instance, _database field is always initialized with a reference to the "EatMyFeats" database
 Other faults: N/A
- */
+*/
+
 using MongoDB.Bson;
 using MongoDB.Driver;
 

--- a/CS Project Manager/Services/ProjectService.cs
+++ b/CS Project Manager/Services/ProjectService.cs
@@ -16,8 +16,6 @@ Other faults: N/A
 using MongoDB.Driver;
 using CS_Project_Manager.Models;
 using MongoDB.Bson;
-using System.Threading.Tasks;
-using System.Collections.Generic;
 
 namespace CS_Project_Manager.Services
 {

--- a/CS Project Manager/Services/RequirementService.cs
+++ b/CS Project Manager/Services/RequirementService.cs
@@ -16,9 +16,6 @@ Other faults: N/A
 using CS_Project_Manager.Models;
 using MongoDB.Driver;
 using MongoDB.Bson;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace CS_Project_Manager.Services
 {

--- a/CS Project Manager/Services/StudentUserService.cs
+++ b/CS Project Manager/Services/StudentUserService.cs
@@ -14,7 +14,6 @@ Invariants: _studentUsers collection is always initialized with the "StudentUser
 Other faults: N/A
 */
 
-
 using MongoDB.Driver;  
 using CS_Project_Manager.Models;
 using MongoDB.Bson;

--- a/CS Project Manager/Services/TeamService.cs
+++ b/CS Project Manager/Services/TeamService.cs
@@ -75,11 +75,5 @@ namespace CS_Project_Manager.Services
         {
             return await _teams.Find(t => t.Id == teamId).FirstOrDefaultAsync();
         }
-
-        public async Task<Team> GetTeamByProjectIdAsync(ObjectId projectId)
-        {
-            var filter = Builders<Team>.Filter.Eq(t => t.Id, projectId);
-            return await _teams.Find(filter).FirstOrDefaultAsync();
-        }
     }
 }

--- a/CS Project Manager/Services/TeamService.cs
+++ b/CS Project Manager/Services/TeamService.cs
@@ -75,5 +75,11 @@ namespace CS_Project_Manager.Services
         {
             return await _teams.Find(t => t.Id == teamId).FirstOrDefaultAsync();
         }
+
+        public async Task<Team> GetTeamByProjectIdAsync(ObjectId projectId)
+        {
+            var filter = Builders<Team>.Filter.Eq(t => t.Id, projectId);
+            return await _teams.Find(filter).FirstOrDefaultAsync();
+        }
     }
 }

--- a/CS Project Manager/Services/TodoService.cs
+++ b/CS Project Manager/Services/TodoService.cs
@@ -16,8 +16,6 @@ Other faults: N/A
 using CS_Project_Manager.Models;
 using MongoDB.Driver;
 using MongoDB.Bson;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace CS_Project_Manager.Services
 {


### PR DESCRIPTION
Added two new database tables: CalendarItems and UserAvailabilityItems
- CalendarItems appear as they currently exist in the schema
- UserAvailabilityItems have ID, associated team ID, day, and time attributes (e.g. "Mon" and "3:00")

Added calendar page:
- The team's availability status shows on the left as a calendar UI
- Availability currently only retrieves by team, not by user
- The team's current planned events show on the right as a bullet list
- The page will notify a user when there are no planned events

Added an Account button to the dashboard

Fixed a crash when clicking the navbar link at the top of the screen while not logged in


Calendar events could possibly be displayed better