### PR TITLE
S[4] - Ability to set personal unavailable times and select other team mates' names to view/unview their personal unavailable times

### DIFF
--- a/CS Project Manager/Models/UserAvailability.cs
+++ b/CS Project Manager/Models/UserAvailability.cs
@@ -15,5 +15,9 @@ namespace CS_Project_Manager.Models
         [BsonElement("AssocUserId")]
         [BsonRepresentation(BsonType.ObjectId)]
         public ObjectId AssocUserId { get; set; }
+
+        [BsonElement("AssocTeamId")]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public ObjectId AssocTeamId { get; set; }
     }
 }

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -44,23 +44,23 @@
         background: rgba(0, 0, 0, 0.5);
         z-index: 999;
     }
-    
+
     .time-slot {
         transition: background-color 0.2s;
     }
 
-    .time-slot:hover {
-        opacity: 0.8;
-    }
-    
+        .time-slot:hover {
+            opacity: 0.8;
+        }
+
     .time-slot-selected {
         background: #87CEEB !important;
     }
-    
+
     .time-slot-to-remove {
-        background: #FF6347 !important; /* Tomato red for slots to be removed */
+        background: #FF6347 !important;
     }
-    
+
     .member-toggle-container {
         margin-bottom: 15px;
         padding: 10px;
@@ -68,7 +68,7 @@
         border-radius: 5px;
         background-color: #f8f9fa;
     }
-    
+
     .member-toggle {
         margin-right: 5px;
     }
@@ -92,19 +92,16 @@
         <div class="row">
             <div class="col-md-6">
                 <h2>Availability Calendar</h2>
-                
-                <!-- Team Member Display Options -->
                 <div class="member-toggle-container mb-3">
                     <h5>Show Team Member Availabilities:</h5>
                     <div class="d-flex flex-wrap" id="memberToggles">
                         @foreach (var member in Model.TeamMemberDisplayOptions)
                         {
                             <div class="form-check me-3 mb-2">
-                                <input class="form-check-input member-toggle" 
-                                       type="checkbox" 
-                                       value="@member.UserId" 
-                                       id="member-@member.UserId" 
-                                       checked="@member.IsDisplayed"
+                                <input class="form-check-input member-toggle"
+                                       type="checkbox"
+                                       value="@member.UserId"
+                                       id="member-@member.UserId"
                                        data-username="@member.Username">
                                 <label class="form-check-label" for="member-@member.UserId">
                                     @member.Username
@@ -113,7 +110,7 @@
                         }
                     </div>
                 </div>
-                
+
                 <div style="display:inline-block;white-space:nowrap;">
                     <div style="font-size:0px;vertical-align:top;">
                         <div class="calendar-box"></div>
@@ -132,13 +129,13 @@
                                 var isUnavailable = matchingSlots.Any();
                                 var availabilityId = isUnavailable ? matchingSlots.First().Id.ToString() : "";
                                 var userId = isUnavailable ? matchingSlots.First().AssocUserId.ToString() : "";
-                                
-                                <div class="calendar-box time-slot" 
-                                     data-day="@day" 
+
+                                <div class="calendar-box time-slot"
+                                     data-day="@day"
                                      data-time="@time"
                                      data-id="@availabilityId"
                                      data-user-id="@userId"
-                                     style="border: 1px black solid; 
+                                     style="border: 1px black solid;
                                             background: @(isUnavailable ? "#000000" : "#ffffff");
                                             cursor: pointer;"
                                      onclick="toggleTimeSlot(this)"></div>
@@ -155,14 +152,12 @@
                 <div style="display:inline-block;font-size:16px;">To Be Removed</div>
                 <div class="legend" style="background: #ffffff;"></div>
                 <div style="display:inline-block;font-size:16px;">Available</div>
-                
+
                 <form id="availabilityForm" method="post" asp-page-handler="UpdateAvailability">
                     <input type="hidden" name="teamId" value="@Model.TeamId" />
                     <div id="selectedTimesContainer">
-                        <!-- Selected times will be added here dynamically -->
                     </div>
                     <div id="removeTimesContainer">
-                        <!-- Times to remove will be added here dynamically -->
                     </div>
                     <button type="button" onclick="submitChanges()" class="btn btn-primary mt-3">Save Changes</button>
                 </form>
@@ -229,19 +224,20 @@
 <script>
     var selectedTimeSlots = [];
     var timeSlotsToRemove = [];
-    document.addEventListener('DOMContentLoaded', function() {
+    document.addEventListener('DOMContentLoaded', function () {
         var memberToggles = document.querySelectorAll('.member-toggle');
-        memberToggles.forEach(function(toggle) {
-            toggle.addEventListener('change', function() {
+        memberToggles.forEach(function (toggle) {
+            toggle.addEventListener('change', function () {
                 updateCalendarDisplay();
             });
+            toggle.checked = false;
         });
         updateCalendarDisplay();
     });
-    
+
     function updateCalendarDisplay() {
         var selectedUserIds = [];
-        document.querySelectorAll('.member-toggle:checked').forEach(function(checkbox) {
+        document.querySelectorAll('.member-toggle:checked').forEach(function (checkbox) {
             selectedUserIds.push(checkbox.value);
         });
         var currentUserId = '@Model.CurrentUserId.ToString()';
@@ -249,7 +245,7 @@
             selectedUserIds.push(currentUserId);
         }
         var timeSlots = document.querySelectorAll('.time-slot');
-        timeSlots.forEach(function(slot) {
+        timeSlots.forEach(function (slot) {
             var userId = slot.getAttribute('data-user-id');
             var availabilityId = slot.getAttribute('data-id');
             if (!availabilityId) {

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -44,6 +44,34 @@
         background: rgba(0, 0, 0, 0.5);
         z-index: 999;
     }
+    
+    .time-slot {
+        transition: background-color 0.2s;
+    }
+
+    .time-slot:hover {
+        opacity: 0.8;
+    }
+    
+    .time-slot-selected {
+        background: #87CEEB !important;
+    }
+    
+    .time-slot-to-remove {
+        background: #FF6347 !important; /* Tomato red for slots to be removed */
+    }
+    
+    .member-toggle-container {
+        margin-bottom: 15px;
+        padding: 10px;
+        border: 1px solid #ddd;
+        border-radius: 5px;
+        background-color: #f8f9fa;
+    }
+    
+    .member-toggle {
+        margin-right: 5px;
+    }
 </style>
 
 <h2>Team Calendar and Events</h2>
@@ -61,119 +89,253 @@
 <div class="navbar-text">
     @if (User.Identity?.IsAuthenticated == true)
     {
-            <div class="row">
-                <div class="col-md-6">
-                    <h2>Availability Calendar</h2>
-                    <div style="display:inline-block;white-space:nowrap;">
-                        <div style="font-size:0px;vertical-align:top;">
-                            <div class="calendar-box"></div>
+        <div class="row">
+            <div class="col-md-6">
+                <h2>Availability Calendar</h2>
+                
+                <!-- Team Member Display Options -->
+                <div class="member-toggle-container mb-3">
+                    <h5>Show Team Member Availabilities:</h5>
+                    <div class="d-flex flex-wrap" id="memberToggles">
+                        @foreach (var member in Model.TeamMemberDisplayOptions)
+                        {
+                            <div class="form-check me-3 mb-2">
+                                <input class="form-check-input member-toggle" 
+                                       type="checkbox" 
+                                       value="@member.UserId" 
+                                       id="member-@member.UserId" 
+                                       checked="@member.IsDisplayed"
+                                       data-username="@member.Username">
+                                <label class="form-check-label" for="member-@member.UserId">
+                                    @member.Username
+                                </label>
+                            </div>
+                        }
+                    </div>
+                </div>
+                
+                <div style="display:inline-block;white-space:nowrap;">
+                    <div style="font-size:0px;vertical-align:top;">
+                        <div class="calendar-box"></div>
                         @foreach (var day in Model.Days)
                         {
-                                    <div class="calendar-box" style="font-size:16px;height:30px">@day</div>
+                            <div class="calendar-box" style="font-size:16px;height:30px">@day</div>
                         }
-                        </div>
+                    </div>
                     @foreach (var time in Model.Times)
                     {
                         <div style="font-size:0px;vertical-align:top;">
                             <div class="calendar-box" style="font-size:12px;">@time</div>
                             @foreach (var day in Model.Days)
                             {
-                                <div class="calendar-box" style="border: 1px black solid; background: @(Model.UserAvailabilityItems.Any(u => u.Day == day && u.Time == time) ? "#000000" : "#ffffff")"></div>
+                                var matchingSlots = Model.UserAvailabilityItems.Where(u => u.Day == day && u.Time == time).ToList();
+                                var isUnavailable = matchingSlots.Any();
+                                var availabilityId = isUnavailable ? matchingSlots.First().Id.ToString() : "";
+                                var userId = isUnavailable ? matchingSlots.First().AssocUserId.ToString() : "";
+                                
+                                <div class="calendar-box time-slot" 
+                                     data-day="@day" 
+                                     data-time="@time"
+                                     data-id="@availabilityId"
+                                     data-user-id="@userId"
+                                     style="border: 1px black solid; 
+                                            background: @(isUnavailable ? "#000000" : "#ffffff");
+                                            cursor: pointer;"
+                                     onclick="toggleTimeSlot(this)"></div>
                             }
                         </div>
                     }
-                    </div>
-                    <br>
-                    <button onclick="openAvailabilityDialog()">Add Unavailable Times</button>
-                    <div class="dialog-overlay" id="availabilityDialogOverlay"></div>
-                    <div class="dialog" id="addAvailabilityDialog">
-                        <form method="post" asp-page-handler="AddUnavailableTime">
-                            <label for="daySelect">Day:</label>
-                            <select id="daySelect" name="SelectedDay">
-                                @foreach (var day in Model.Days)
-                                {
-                                    <option value="@day">@day</option>
-                                }
-                            </select>
-
-                            <label for="timeSelect">Time:</label>
-                            <select id="timeSelect" name="SelectedTime">
-                                @foreach (var time in Model.Times)
-                                {
-                                    <option value="@time">@time</option>
-                                }
-                            </select>
-
-                            <button type="submit">Save</button>
-                            <button type="button" onclick="closeAvailabilityDialog()">Cancel</button>
-                        </form>
-                    </div>
-                    <div class="calendar-box"></div>
-                    <div class="legend" style="background: #000000;"></div>
-                    <div style="display:inline-block;font-size:16px;">Unavailable</div>
-                    <div class="legend" style="background: #ffffff;"></div>
-                    <div style="display:inline-block;font-size:16px;">Available</div>
                 </div>
-                <div class="col-md-6">
-                    <h2>Event List</h2>
-                    <div id="EventList">
+                <br><br>
+                <div class="legend" style="background: #000000;"></div>
+                <div style="display:inline-block;font-size:16px;">Unavailable</div>
+                <div class="legend" style="background: #87CEEB;"></div>
+                <div style="display:inline-block;font-size:16px;">Selected</div>
+                <div class="legend" style="background: #FF6347;"></div>
+                <div style="display:inline-block;font-size:16px;">To Be Removed</div>
+                <div class="legend" style="background: #ffffff;"></div>
+                <div style="display:inline-block;font-size:16px;">Available</div>
+                
+                <form id="availabilityForm" method="post" asp-page-handler="UpdateAvailability">
+                    <input type="hidden" name="teamId" value="@Model.TeamId" />
+                    <div id="selectedTimesContainer">
+                        <!-- Selected times will be added here dynamically -->
+                    </div>
+                    <div id="removeTimesContainer">
+                        <!-- Times to remove will be added here dynamically -->
+                    </div>
+                    <button type="button" onclick="submitChanges()" class="btn btn-primary mt-3">Save Changes</button>
+                </form>
+            </div>
+            <div class="col-md-6">
+                <h2>Event List</h2>
+                <div id="EventList">
                     @if (Model.TeamCalendarItems.Count > 0)
                     {
-                                <ul>
+                        <ul>
                             @foreach (var item in Model.TeamCalendarItems)
                             {
-                                            <li>
-                                                <a href="javascript:void(0)" onclick="openDialog('@item.EventName', '@Model.ConvertToCentralTime(item.StartDateTime).ToString("yyyy-MM-ddTHH:mm")', '@Model.ConvertToCentralTime(item.EndDateTime).ToString("yyyy-MM-ddTHH:mm")', '@item.Notes', '@item.Id')">
+                                <li>
+                                    <a href="javascript:void(0)" onclick="openDialog('@item.EventName', '@Model.ConvertToCentralTime(item.StartDateTime).ToString("yyyy-MM-ddTHH:mm")', '@Model.ConvertToCentralTime(item.EndDateTime).ToString("yyyy-MM-ddTHH:mm")', '@item.Notes', '@item.Id')">
                                         @item.EventName: @Model.ConvertToCentralTime(item.StartDateTime).ToString()
-                                                </a>
-                                            </li>
+                                    </a>
+                                </li>
                             }
-                                </ul>
+                        </ul>
                     }
                     else
                     {
-                                <p>No scheduled events!</p>
+                        <p>No scheduled events!</p>
                     }
-                    </div>
-                    <button onclick="openDialog()">Add Meeting</button>
                 </div>
+                <button onclick="openDialog()">Add Meeting</button>
             </div>
+        </div>
 
-            <div class="dialog-overlay" id="dialogOverlay"></div>
-            <div class="dialog" id="addMeetingDialog">
-                <form method="post" asp-page-handler="AddOrUpdateCalendarItem" onsubmit="return validateForm()">
-                    <input type="hidden" name="teamId" value="@Model.TeamId" />
-                    <input type="hidden" id="calendarItemId" name="NewCalendarItem.Id" />
-                    <div>
-                        <label for="meetingName">Meeting Name:</label>
-                        <input type="text" id="meetingName" name="NewCalendarItem.EventName" required />
-                    </div>
-                    <div>
-                        <label for="startTime">Start Time:</label>
-                        <input type="datetime-local" id="startTime" name="NewCalendarItem.StartDateTime" required />
-                    </div>
-                    <div>
-                        <label for="endTime">End Time:</label>
-                        <input type="datetime-local" id="endTime" name="NewCalendarItem.EndDateTime" required />
-                    </div>
-                    <div>
-                        <label for="notes">Notes:</label>
-                        <textarea id="notes" name="NewCalendarItem.Notes"></textarea>
-                    </div>
-                    <div>
-                        <button type="submit">Confirm</button>
-                        <button type="button" onclick="closeDialog()">Cancel</button>
-                    </div>
-                </form>
-            </div>
+        <div class="dialog-overlay" id="dialogOverlay"></div>
+        <div class="dialog" id="addMeetingDialog">
+            <form method="post" asp-page-handler="AddOrUpdateCalendarItem" onsubmit="return validateForm()">
+                <input type="hidden" name="teamId" value="@Model.TeamId" />
+                <input type="hidden" id="calendarItemId" name="NewCalendarItem.Id" />
+                <div>
+                    <label for="meetingName">Meeting Name:</label>
+                    <input type="text" id="meetingName" name="NewCalendarItem.EventName" required />
+                </div>
+                <div>
+                    <label for="startTime">Start Time:</label>
+                    <input type="datetime-local" id="startTime" name="NewCalendarItem.StartDateTime" required />
+                </div>
+                <div>
+                    <label for="endTime">End Time:</label>
+                    <input type="datetime-local" id="endTime" name="NewCalendarItem.EndDateTime" required />
+                </div>
+                <div>
+                    <label for="notes">Notes:</label>
+                    <textarea id="notes" name="NewCalendarItem.Notes"></textarea>
+                </div>
+                <div>
+                    <button type="submit">Confirm</button>
+                    <button type="button" onclick="closeDialog()">Cancel</button>
+                </div>
+            </form>
+        </div>
     }
     else
     {
-            <span>Not logged in</span>
+        <span>Not logged in</span>
     }
 </div>
 
 <script>
+    var selectedTimeSlots = [];
+    var timeSlotsToRemove = [];
+    document.addEventListener('DOMContentLoaded', function() {
+        var memberToggles = document.querySelectorAll('.member-toggle');
+        memberToggles.forEach(function(toggle) {
+            toggle.addEventListener('change', function() {
+                updateCalendarDisplay();
+            });
+        });
+        updateCalendarDisplay();
+    });
+    
+    function updateCalendarDisplay() {
+        var selectedUserIds = [];
+        document.querySelectorAll('.member-toggle:checked').forEach(function(checkbox) {
+            selectedUserIds.push(checkbox.value);
+        });
+        var currentUserId = '@Model.CurrentUserId.ToString()';
+        if (currentUserId && !selectedUserIds.includes(currentUserId)) {
+            selectedUserIds.push(currentUserId);
+        }
+        var timeSlots = document.querySelectorAll('.time-slot');
+        timeSlots.forEach(function(slot) {
+            var userId = slot.getAttribute('data-user-id');
+            var availabilityId = slot.getAttribute('data-id');
+            if (!availabilityId) {
+                return;
+            }
+            if (selectedUserIds.includes(userId)) {
+                slot.style.background = "#000000";
+                slot.classList.add('visible-availability');
+            } else {
+                slot.style.background = "#ffffff";
+                slot.classList.remove('visible-availability');
+            }
+            if (timeSlotsToRemove.includes(availabilityId)) {
+                slot.style.background = "#FF6347";
+            }
+            var day = slot.getAttribute('data-day');
+            var time = slot.getAttribute('data-time');
+            if (selectedTimeSlots.some(s => s.day === day && s.time === time)) {
+                slot.style.background = "#87CEEB";
+            }
+        });
+    }
+
+    function toggleTimeSlot(element) {
+        var day = element.getAttribute('data-day');
+        var time = element.getAttribute('data-time');
+        var id = element.getAttribute('data-id');
+        var userId = element.getAttribute('data-user-id');
+        var isUnavailable = id !== "";
+        var isCurrentUser = userId === '@Model.CurrentUserId.ToString()';
+        if (!isUnavailable || isCurrentUser) {
+            if (!isUnavailable) {
+                var index = selectedTimeSlots.findIndex(slot => slot.day === day && slot.time === time);
+                if (index === -1) {
+                    selectedTimeSlots.push({ day: day, time: time });
+                    element.style.background = "#87CEEB";
+                } else {
+                    selectedTimeSlots.splice(index, 1);
+                    element.style.background = "#ffffff";
+                }
+            } else if (isCurrentUser) {
+                var index = timeSlotsToRemove.findIndex(slotId => slotId === id);
+                if (index === -1) {
+                    timeSlotsToRemove.push(id);
+                    element.style.background = "#FF6347";
+                } else {
+                    timeSlotsToRemove.splice(index, 1);
+                    element.style.background = "#000000";
+                }
+            }
+            updateCalendarDisplay();
+        }
+    }
+
+    function submitChanges() {
+        var hasChanges = selectedTimeSlots.length > 0 || timeSlotsToRemove.length > 0;
+        if (!hasChanges) {
+            alert("No changes to save. Please select or deselect time slots first.");
+            return;
+        }
+        var addContainer = document.getElementById('selectedTimesContainer');
+        var removeContainer = document.getElementById('removeTimesContainer');
+        addContainer.innerHTML = '';
+        removeContainer.innerHTML = '';
+        selectedTimeSlots.forEach((slot, index) => {
+            var dayInput = document.createElement('input');
+            dayInput.type = 'hidden';
+            dayInput.name = `SelectedDays[${index}]`;
+            dayInput.value = slot.day;
+            var timeInput = document.createElement('input');
+            timeInput.type = 'hidden';
+            timeInput.name = `SelectedTimes[${index}]`;
+            timeInput.value = slot.time;
+            addContainer.appendChild(dayInput);
+            addContainer.appendChild(timeInput);
+        });
+        timeSlotsToRemove.forEach((id, index) => {
+            var idInput = document.createElement('input');
+            idInput.type = 'hidden';
+            idInput.name = `RemoveIds[${index}]`;
+            idInput.value = id;
+            removeContainer.appendChild(idInput);
+        });
+        document.getElementById('availabilityForm').submit();
+    }
+
     function openDialog(eventName = '', startTime = '', endTime = '', notes = '', id = '') {
         document.getElementById('meetingName').value = eventName;
         document.getElementById('startTime').value = startTime;
@@ -192,21 +354,10 @@
     function validateForm() {
         var startTime = document.getElementById('startTime').value;
         var endTime = document.getElementById('endTime').value;
-
         if (new Date(startTime) >= new Date(endTime)) {
             alert('End Time must be later than Start Time.');
             return false;
         }
         return true;
-    }
-
-    function openAvailabilityDialog() {
-        document.getElementById('addAvailabilityDialog').style.display = 'block';
-        document.getElementById('availabilityDialogOverlay').style.display = 'block';
-    }
-
-    function closeAvailabilityDialog() {
-        document.getElementById('addAvailabilityDialog').style.display = 'none';
-        document.getElementById('availabilityDialogOverlay').style.display = 'none';
     }
 </script>

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -54,7 +54,7 @@
         }
 
     .time-slot-selected {
-        background: #87CEEB !important;
+        background: #80EF80 !important;
     }
 
     .time-slot-to-remove {
@@ -146,7 +146,7 @@
                 <br><br>
                 <div class="legend" style="background: #000000;"></div>
                 <div style="display:inline-block;font-size:16px;">Unavailable</div>
-                <div class="legend" style="background: #87CEEB;"></div>
+                <div class="legend" style="background: #80EF80;"></div>
                 <div style="display:inline-block;font-size:16px;">Selected</div>
                 <div class="legend" style="background: #FF6347;"></div>
                 <div style="display:inline-block;font-size:16px;">To Be Removed</div>
@@ -264,7 +264,7 @@
             var day = slot.getAttribute('data-day');
             var time = slot.getAttribute('data-time');
             if (selectedTimeSlots.some(s => s.day === day && s.time === time)) {
-                slot.style.background = "#87CEEB";
+                slot.style.background = "#80EF80";
             }
         });
     }
@@ -281,7 +281,7 @@
                 var index = selectedTimeSlots.findIndex(slot => slot.day === day && slot.time === time);
                 if (index === -1) {
                     selectedTimeSlots.push({ day: day, time: time });
-                    element.style.background = "#87CEEB";
+                    element.style.background = "#80EF80";
                 } else {
                     selectedTimeSlots.splice(index, 1);
                     element.style.background = "#ffffff";

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -74,16 +74,40 @@
                         </div>
                     @foreach (var time in Model.Times)
                     {
-                                <div style="font-size:0px;vertical-align:top;">
-                                    <div class="calendar-box" style="font-size:12px;">@time</div>
+                        <div style="font-size:0px;vertical-align:top;">
+                            <div class="calendar-box" style="font-size:12px;">@time</div>
                             @foreach (var day in Model.Days)
                             {
-                                            <div class="calendar-box" style="border: 1px black solid; background: @(Model.UserAvailabilityItems.Any(u => u.Day == day && u.Time == time) ? "#000000" : "#ffffff")"></div>
+                                <div class="calendar-box" style="border: 1px black solid; background: @(Model.UserAvailabilityItems.Any(u => u.Day == day && u.Time == time) ? "#000000" : "#ffffff")"></div>
                             }
-                                </div>
+                        </div>
                     }
                     </div>
                     <br>
+                    <button onclick="openAvailabilityDialog()">Add Unavailable Times</button>
+                    <div class="dialog-overlay" id="availabilityDialogOverlay"></div>
+                    <div class="dialog" id="addAvailabilityDialog">
+                        <form method="post" asp-page-handler="AddUnavailableTime">
+                            <label for="daySelect">Day:</label>
+                            <select id="daySelect" name="SelectedDay">
+                                @foreach (var day in Model.Days)
+                                {
+                                    <option value="@day">@day</option>
+                                }
+                            </select>
+
+                            <label for="timeSelect">Time:</label>
+                            <select id="timeSelect" name="SelectedTime">
+                                @foreach (var time in Model.Times)
+                                {
+                                    <option value="@time">@time</option>
+                                }
+                            </select>
+
+                            <button type="submit">Save</button>
+                            <button type="button" onclick="closeAvailabilityDialog()">Cancel</button>
+                        </form>
+                    </div>
                     <div class="calendar-box"></div>
                     <div class="legend" style="background: #000000;"></div>
                     <div style="display:inline-block;font-size:16px;">Unavailable</div>
@@ -174,5 +198,15 @@
             return false;
         }
         return true;
+    }
+
+    function openAvailabilityDialog() {
+        document.getElementById('addAvailabilityDialog').style.display = 'block';
+        document.getElementById('availabilityDialogOverlay').style.display = 'block';
+    }
+
+    function closeAvailabilityDialog() {
+        document.getElementById('addAvailabilityDialog').style.display = 'none';
+        document.getElementById('availabilityDialogOverlay').style.display = 'none';
     }
 </script>

--- a/CS Project Manager/Pages/Calendar.cshtml.cs
+++ b/CS Project Manager/Pages/Calendar.cshtml.cs
@@ -129,7 +129,6 @@ namespace CS_Project_Manager.Pages
                 AssocTeamId = teamId
             };
             await _userAvailabilityService.AddUserAvailabilityAsync(newAvailability);
-            // Reload availability after adding new entry
             UserAvailabilityItems = new List<UserAvailability>();
             await LoadUserAvailabilityAsync(teamId);
             return RedirectToPage("/Calendar", new { teamId });
@@ -144,16 +143,11 @@ namespace CS_Project_Manager.Pages
 
         private async Task LoadUserAvailabilityAsync(ObjectId teamId)
         {
-            // Make sure ProjectTeam is loaded
             if (ProjectTeam == null)
             {
                 ProjectTeam = await _teamService.GetTeamByIdAsync(teamId);
             }
-
-            // Clear existing items
             UserAvailabilityItems = await _userAvailabilityService.GetUserAvailabilityByTeamIdAsync(teamId);
-
-            // Make sure ProjectTeam and Members are not null before iterating
             if (ProjectTeam?.Members != null)
             {
                 foreach (var user in ProjectTeam.Members)

--- a/CS Project Manager/Program.cs
+++ b/CS Project Manager/Program.cs
@@ -76,6 +76,7 @@ builder.Services.AddScoped<BrainstormService>();
 builder.Services.AddScoped<CalendarService>();
 builder.Services.AddScoped<DiscussionBoardService>();
 builder.Services.AddScoped<DiscussionPostService>();
+builder.Services.AddScoped<UserAvailabilityService>();
 
 var app = builder.Build(); // Build app from configured builder
 

--- a/CS Project Manager/Services/CalendarService.cs
+++ b/CS Project Manager/Services/CalendarService.cs
@@ -51,13 +51,5 @@ namespace CS_Project_Manager.Services
             var filter = Builders<CalendarItem>.Filter.Eq(c => c.Id, updatedCalendarItem.Id);
             await _calendarItems.ReplaceOneAsync(filter, updatedCalendarItem);
         }
-
-        // gets a user availability item by its ID
-        public async Task GetUserAvailabilityByIdAsync(ObjectId id) =>
-            await _userAvailability.Find(u => u.Id == id).FirstOrDefaultAsync();
-
-        // gets user availability items by their team ID
-        public async Task<List<UserAvailability>> GetUserAvailabilityByUserIdAsync(ObjectId userId) =>
-            await _userAvailability.Find(u => u.AssocUserId == userId).ToListAsync();
     }
 }

--- a/CS Project Manager/Services/CalendarService.cs
+++ b/CS Project Manager/Services/CalendarService.cs
@@ -2,8 +2,8 @@
 * Prologue
 Created By: Jackson Wunderlich
 Date Created: 3/24/25
-Last Revised By: Anakha Krishna
-Date Revised: 3/28/25
+Last Revised By: Dylan Sailors
+Date Revised: 3/30/25
 Purpose: Provides data access methods for calendar operations in the database
 Preconditions: MongoDB setup, CalendarItems table exists, CalendarItem model defined
 Postconditions: new CalendarItem items can be added, items can be updated and removed

--- a/CS Project Manager/Services/UserAvailabilityService.cs
+++ b/CS Project Manager/Services/UserAvailabilityService.cs
@@ -1,15 +1,15 @@
 /*
 * Prologue
-Created By: Jackson Wunderlich
-Date Created: 3/24/25
-Last Revised By: Anakha Krishna
-Date Revised: 3/28/25
-Purpose: Provides data access methods for calendar operations in the database
-Preconditions: MongoDB setup, CalendarItems table exists, CalendarItem model defined
-Postconditions: new CalendarItem items can be added, items can be updated and removed
+Created By: Dylan Sailors
+Date Created: 3/30/25
+Last Revised By: Dylan Sailors
+Date Revised: 3/30/25
+Purpose: Provides data access methods for user availability operations in the database
+Preconditions: MongoDB setup, UserAvailability table exists, UserAvailability model defined
+Postconditions: new UserAvailability entries can be added, entries can be updated and removed
 Error and exceptions: MongoDB.Driver.MongoException (thrown if there is an issue with the MongoDB connection or operations)
 Side effects: N/A
-Invariants: _calendarItems collection is always initialized with the "CalendarItems" collection from the MongoDB database
+Invariants: _userAvailability collection is always initialized with the "UserAvailability" collection from the MongoDB database
 Other faults: N/A
 */
 
@@ -24,22 +24,46 @@ namespace CS_Project_Manager.Services
     public class UserAvailabilityService
     {
         private readonly IMongoCollection<UserAvailability> _userAvailability;
-
+        
         public UserAvailabilityService(MongoDBService mongoDBService)
         {
             _userAvailability = mongoDBService.GetCollection<UserAvailability>("UserAvailabilityItems");
         }
-
-        public async Task<UserAvailability?> GetUserAvailabilityByIdAsync(ObjectId id) =>
+        
+        // gets the user's availability by their ID
+        public async Task<UserAvailability> GetUserAvailabilityByIdAsync(ObjectId id) =>
             await _userAvailability.Find(u => u.Id == id).FirstOrDefaultAsync();
-
+        
+        // gets the user's availability by their user ID
         public async Task<List<UserAvailability>> GetUserAvailabilityByUserIdAsync(ObjectId userId) =>
             await _userAvailability.Find(u => u.AssocUserId == userId).ToListAsync();
-
+        
+        // gets the user's availability by their team ID
         public async Task<List<UserAvailability>> GetUserAvailabilityByTeamIdAsync(ObjectId teamId) =>
             await _userAvailability.Find(u => u.AssocTeamId == teamId).ToListAsync();
-
+        
+        // adds a new user's availability
         public async Task AddUserAvailabilityAsync(UserAvailability availability) =>
             await _userAvailability.InsertOneAsync(availability);
+        
+        // removes a user's availability by their ID
+        public async Task DeleteUserAvailabilityAsync(ObjectId id) =>
+            await _userAvailability.DeleteOneAsync(x => x.Id == id);
+            
+        // updates a user's availability by their ID
+        public async Task UpdateUserAvailabilityAsync(UserAvailability availability)
+        {
+            var filter = Builders<UserAvailability>.Filter.Eq(x => x.Id, availability.Id);
+            await _userAvailability.ReplaceOneAsync(filter, availability);
+        }
+        
+        // updates a user's availability team ID by their user ID
+        public async Task UpdateUserAvailabilityTeamIdAsync(ObjectId userId, ObjectId newTeamId)
+        {
+            var filter = Builders<UserAvailability>.Filter.Eq(x => x.AssocUserId, userId);
+            var update = Builders<UserAvailability>.Update.Set(x => x.AssocTeamId, newTeamId);
+            
+            await _userAvailability.UpdateManyAsync(filter, update);
+        }
     }
 }

--- a/CS Project Manager/Services/UserAvailabilityService.cs
+++ b/CS Project Manager/Services/UserAvailabilityService.cs
@@ -1,0 +1,45 @@
+/*
+* Prologue
+Created By: Jackson Wunderlich
+Date Created: 3/24/25
+Last Revised By: Anakha Krishna
+Date Revised: 3/28/25
+Purpose: Provides data access methods for calendar operations in the database
+Preconditions: MongoDB setup, CalendarItems table exists, CalendarItem model defined
+Postconditions: new CalendarItem items can be added, items can be updated and removed
+Error and exceptions: MongoDB.Driver.MongoException (thrown if there is an issue with the MongoDB connection or operations)
+Side effects: N/A
+Invariants: _calendarItems collection is always initialized with the "CalendarItems" collection from the MongoDB database
+Other faults: N/A
+*/
+
+using CS_Project_Manager.Models;
+using MongoDB.Driver;
+using MongoDB.Bson;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CS_Project_Manager.Services
+{
+    public class UserAvailabilityService
+    {
+        private readonly IMongoCollection<UserAvailability> _userAvailability;
+
+        public UserAvailabilityService(MongoDBService mongoDBService)
+        {
+            _userAvailability = mongoDBService.GetCollection<UserAvailability>("UserAvailabilityItems");
+        }
+
+        public async Task<UserAvailability?> GetUserAvailabilityByIdAsync(ObjectId id) =>
+            await _userAvailability.Find(u => u.Id == id).FirstOrDefaultAsync();
+
+        public async Task<List<UserAvailability>> GetUserAvailabilityByUserIdAsync(ObjectId userId) =>
+            await _userAvailability.Find(u => u.AssocUserId == userId).ToListAsync();
+
+        public async Task<List<UserAvailability>> GetUserAvailabilityByTeamIdAsync(ObjectId teamId) =>
+            await _userAvailability.Find(u => u.AssocTeamId == teamId).ToListAsync();
+
+        public async Task AddUserAvailabilityAsync(UserAvailability availability) =>
+            await _userAvailability.InsertOneAsync(availability);
+    }
+}


### PR DESCRIPTION
- Changed the availability calendar to be interactive (click on that thing) along with updating the Key at the bottom to reflect what each color means
- You can add your unavailable times, remove them, update them etc. 
- Database has ObjectID's for both the AssocUserId and the AssocTeamId (had to do this to make it work)
- Able to select which team members' availabilities you can see. They all start selected so the calendar is populated and then you can unselect who you don't want to see.
     - No feature to toggle your own availability. If you want that added let me know
- When a user changes teams, their unavailable times moves with them (respective ObjectIds change in the database when the team change occurs)
- When a user changes teams, their unavailable times removes themselves from the old team's calendar.

I did my testing using rawrxd (password: rawr) and dylantest (password: dylantest). You don't have to use these accounts to test, but when you do test I think Team 24 and Team 12 in EECS 582 have semi-populated calendars (Team 24 much more than Team 12) so use those teams unless you want to start populating your own team's calendar.