### PR TITLE
[S5] Add a way to add a team/class once youve already registered

### DIFF
--- a/CS Project Manager/Pages/AccountEdit.cshtml
+++ b/CS Project Manager/Pages/AccountEdit.cshtml
@@ -82,4 +82,24 @@
     </select>
     <button type="submit">Add Team</button>
 </form>
+
+<h3>Create Team</h3>
+<form method="post" asp-page-handler="CreateTeam">
+    <div>
+        <label>Team Name</label>
+        <input asp-for="NewTeamName" required />
+    </div>
+    <div>
+        <label>Associated Class</label>
+        <select asp-for="AssociatedClassId" required>
+            <option value="">Select a class</option>
+            @foreach (var enrolledClass in Model.EnrolledClasses)
+            {
+                <option value="@enrolledClass.Id">@enrolledClass.Name</option>
+            }
+        </select>
+    </div>
+    <button type="submit">Create and Join Team</button>
+</form>
+
 <a href="/Account" class="btn btn-primary">Back to account page</a>

--- a/CS Project Manager/Pages/AccountEdit.cshtml
+++ b/CS Project Manager/Pages/AccountEdit.cshtml
@@ -48,11 +48,13 @@
 <h3>Add Class</h3>
 <form method="post" asp-page-handler="AddClass">
     <select asp-for="SelectedClassId">
+        <option value=""> Select a class </option>
         @foreach (var availableClass in Model.AvailableClasses)
         {
             <option value="@availableClass.Id">@availableClass.Name</option>
         }
     </select>
+    <input asp-for="NewClassName" placeholder="Or enter new class name" />
     <button type="submit">Add Class</button>
 </form>
 

--- a/CS Project Manager/Pages/Register.cshtml
+++ b/CS Project Manager/Pages/Register.cshtml
@@ -42,6 +42,10 @@
         <select id="enrolledClasses" name="EnrolledClasses" multiple="multiple" style="width: 100%;"></select>
     </div>
 
+    
+<div id="teamSelectors"></div>
+
+
     <button type="submit">Register</button>
 </form>
 
@@ -93,12 +97,80 @@
             });
 
             $('#enrolledClasses').on('change', function () {
-                let newSelectedClasses = $(this).val() || [];
+                let newSelectedClasses = $(this).val()
+                updateTeamSelectors(newSelectedClasses);
             });
 
             $('#enrolledClasses').trigger('change');
         }
+
+        function updateTeamSelectors(selectedClasses) {
+            const container = $('#teamSelectors');
+            const currentSelectors = new Set();
+
+            // Track current team selectors in the DOM
+            container.find('.team-selector').each(function () {
+                const className = $(this).data('class');
+                currentSelectors.add(className);
+            });
+
+            // Add selectors for new classes
+            selectedClasses.forEach(className => {
+                if (!currentSelectors.has(className)) {
+                    const safeId = className.replace(/[^a-zA-Z0-9]/g, '_');
+                    const teamSelector = $(`
+                        <div class="team-selector" data-class="${className}">
+                            <label>Select team for ${className}</label>
+                            <select id="team_${safeId}" name="SelectedTeams[${className}]" style="width: 100%;"></select>
+                        </div>
+                    `);
+
+                    container.append(teamSelector);
+
+                    $(`#team_${safeId}`).select2({
+                        tags: true,
+                        placeholder: "Select or add a team",
+                        ajax: {
+                            url: '/Register?handler=GetTeams',
+                            dataType: 'json',
+                            delay: 250,
+                            data: params => ({ term: params.term, className }),
+                            processResults: data => ({
+                                results: data.map(team => ({ id: team.name, text: team.name }))
+                            }),
+                            cache: true
+                        },
+                        createTag: function (params) {
+                            let term = $.trim(params.term);
+                            if (!term || term.length > 100) return null;
+                            return {
+                                id: term,
+                                text: `Add New Team: ${term}`,
+                                newTag: true
+                            };
+                        },
+                        templateSelection: data => data.newTag ? data.id : data.text
+                    });
+                }
+            });
+
+            // Remove selectors for deselected classes
+            container.find('.team-selector').each(function () {
+                const className = $(this).data('class');
+                if (!selectedClasses.includes(className)) {
+                    $(this).remove();
+                }
+            });
+        }
+
+
+            $('#enrolledClasses').on('change', function () {
+        const selected = $(this).val() || [];
+        updateTeamSelectors(selected);
+    });
+
     });
 
 </script>
+
 

--- a/CS Project Manager/Pages/Register.cshtml
+++ b/CS Project Manager/Pages/Register.cshtml
@@ -18,7 +18,7 @@
 
 <form method="post">
     <div>
-        <label>Email</label>
+        <label>KU Email</label>
         <input asp-for="Email" type="email" maxlength="255" />
     </div>
 
@@ -164,10 +164,10 @@
         }
 
 
-            $('#enrolledClasses').on('change', function () {
-        const selected = $(this).val() || [];
-        updateTeamSelectors(selected);
-    });
+        $('#enrolledClasses').on('change', function () {
+            const selected = $(this).val() || [];
+            updateTeamSelectors(selected);
+        });
 
     });
 

--- a/CS Project Manager/Pages/Register.cshtml
+++ b/CS Project Manager/Pages/Register.cshtml
@@ -42,11 +42,6 @@
         <select id="enrolledClasses" name="EnrolledClasses" multiple="multiple" style="width: 100%;"></select>
     </div>
 
-    <div>
-        <label>Team</label>
-        <select id="team" name="Teams" multiple="multiple" style="width: 100%;"></select>
-    </div>
-
     <button type="submit">Register</button>
 </form>
 
@@ -60,7 +55,6 @@
         // select2 cannot filter from ajax queries, item must have local data
         // perform queries and store results in these arrays
         let classData = [];
-        let teamData = [];
         let selectedClasses = [];
 
         // Fetch all classes initially and store them
@@ -73,38 +67,6 @@
                 initializeClassDropdown();
             }
         });
-
-        // Fetch teams for the selected classes
-        function fetchTeamsForClasses(newSelectedClasses) {
-            let removedClasses = selectedClasses.filter(cls => !newSelectedClasses.includes(cls));
-
-            // Remove teams belonging to deselected classes
-            teamData = teamData.filter(team => {
-                let className = team.text.match(/\((.*?)\)$/)?.[1]; // Extract class name from "Team (Class)"
-                return className && !removedClasses.includes(className);
-            });
-            
-            // Explicitly clear the team dropdown before reinitializing
-            $('#team').empty().trigger('change');
-
-            $.ajax({
-                type: 'get',
-                url: '/Register?handler=GetTeamsForClasses',
-                data: { "cs": newSelectedClasses },
-                traditional: true,
-                success: function (data) {
-                    let newTeams = data.map(item => ({ id: item.name, text: item.name }));
-
-                    // Avoid duplicate teams in the dropdown
-                    teamData = [...teamData, ...newTeams.filter(team => !teamData.some(t => t.id === team.id))];
-
-                    initializeTeamDropdown(); // Reinitialize dropdown with updated team data
-                }
-            });
-
-            // Update selected classes for future tracking
-            selectedClasses = newSelectedClasses;
-        }
 
         // Initialize class dropdown
         function initializeClassDropdown() {
@@ -132,71 +94,9 @@
 
             $('#enrolledClasses').on('change', function () {
                 let newSelectedClasses = $(this).val() || [];
-                fetchTeamsForClasses(newSelectedClasses);
             });
 
-            // Trigger an initial team fetch to load any pre-selected classes
             $('#enrolledClasses').trigger('change');
-        }
-
-        // Initialize team dropdown
-        function initializeTeamDropdown() {
-            $('#team').select2({
-                tags: true,
-                placeholder: "Select or add a team",
-                data: selectedClasses.length === 0 ? [{ id: 'no-class', text: 'Please select a class', disabled: true }] : teamData,
-                createTag: function (params) {
-                    let term = $.trim(params.term);
-                    if (!term) return null;
-
-                    // Show a message when no class is selected
-                    if (selectedClasses.length === 0) {
-                        return [{ id: 'no-class', text: 'Please select a class', disabled: true }]; // Prevents adding a team when no class is selected
-                    }
-
-                     // Create new team options for each selected class
-                    return selectedClasses.map(cls => ({
-                        id: `${term} (${cls})`,
-                        text: `Add New Team: ${term} (${cls})`,
-                        newTag: true
-                    }));
-                },
-                insertTag: function (data, newTags) {
-                    newTags.forEach(tag => {
-                        if (!data.some(existingTag => existingTag.text === tag.text)) {
-                            console.log("tag pushed");
-                            data.push(tag);
-                        }
-                    });
-                },
-                templateSelection: function (data) {
-                    return data.newTag ? data.id : data.text;
-                }
-            });
-
-            // Ensure dropdown updates when clicking on the field
-            $('#team').on('select2:open', function () {
-                let select2Data = $('#team').data('select2');
-                let $options = select2Data.$results.find('.select2-results__option');
-
-                // Remove duplicate "Please select a class" messages before adding a new one
-                $options.filter(function () {
-                    return $(this).text() === "Please select a class";
-                }).remove();
-
-                // If no class is selected, show the message
-                if (selectedClasses.length === 0) {
-                    // Add only if it does not already exist
-                    if ($('#team option[value="no-class"]').length === 0) {
-                        let $option = $('<option>')
-                            .val('no-class')
-                            .text('Please select a class')
-                            .prop('disabled', true);
-
-                        $('#team').append($option).trigger('change');
-                    }
-                }
-            });
         }
     });
 

--- a/CS Project Manager/Pages/Register.cshtml.cs
+++ b/CS Project Manager/Pages/Register.cshtml.cs
@@ -3,7 +3,7 @@
 Created By: Isabel Loney
 Date Created: 2/25/25
 Last Revised By: Isabel Loney
-Date Revised: 3/26/25
+Date Revised: 4/10/25
 Purpose: Handles user registration by creating new accounts, validating inputs, checking for existing accounts
 
 Preconditions: MongoDBService, StudentUserService, TeamService, ClassService instances properly initialized and injected; StudentUser, Team, and Class model must be correctly defined

--- a/CS Project Manager/Pages/RequirementsStack.cshtml.cs
+++ b/CS Project Manager/Pages/RequirementsStack.cshtml.cs
@@ -72,8 +72,10 @@ namespace CS_Project_Manager.Pages
             var curTeam = await _teamService.GetTeamByIdAsync(currentProject.AssociatedTeam);
             AssocTeamId = currentProject.AssociatedTeam;
 
-            TeamMembers = (await Task.WhenAll(curTeam.Members
-                .Select(member => _studentUserService.GetUserByIdAsync(member)))).ToList();
+            var users = await Task.WhenAll(curTeam.Members
+                .Select(member => _studentUserService.GetUserByIdAsync(member)));
+
+            TeamMembers = users.Where(user => user != null).ToList();
         }
 
         // Add a new requirement

--- a/CS Project Manager/Services/ClassService.cs
+++ b/CS Project Manager/Services/ClassService.cs
@@ -51,15 +51,6 @@ namespace CS_Project_Manager.Services
             return await _classes.Find(_ => true).ToListAsync();
         }
 
-        public async Task<Dictionary<ObjectId, string>> GetClassIdToName(string[] cs)
-        {
-            var classMapping = await _classes
-                .Find(c => cs.Contains(c.Name))
-                .Project(c => new { c.Id, c.Name })
-                .ToListAsync();
-            return classMapping.ToDictionary(c => c.Id, c => c.Name);
-        }
-
         public async Task<Dictionary<ObjectId, string>> GetClassIdToNameById(ObjectId[] classIds)
         {
             var classMapping = await _classes

--- a/CS Project Manager/Services/ClassService.cs
+++ b/CS Project Manager/Services/ClassService.cs
@@ -2,8 +2,8 @@
 * Prologue
 Created By: Isabel Loney
 Date Created: 2/25/25
-Last Revised By: Anakha Krishna
-Date Revised: 3/2/25
+Last Revised By: Isabel Loney
+Date Revised: 4/10/25
 Purpose: Provides data access methods for class-related operations in the MongoDB database
 
 Preconditions: MongoDB setup, Class table exists, Class model defined

--- a/CS Project Manager/Services/TeamService.cs
+++ b/CS Project Manager/Services/TeamService.cs
@@ -28,22 +28,15 @@ namespace CS_Project_Manager.Services
         public async Task CreateTeamAsync(Team team) =>
             await _teams.InsertOneAsync(team);
 
-        public async Task<List<Team>> GetAllTeamsAsync()
-        {
-            var filter = Builders<Team>.Filter.Empty;
-            var team_list = await _teams.Find(filter).ToListAsync();
-            return team_list;
-        }
-
         public async Task<Team> GetTeamByNameAndClassId(string teamName, ObjectId classId)
         {
             return await _teams.Find(t => t.Name == teamName && t.AssociatedClass == classId).FirstOrDefaultAsync();
         }
 
-        public async Task<List<Team>> GetTeamsByClassNames(Dictionary<ObjectId, string> classIdToName)
+        public async Task<List<Team>> GetTeamsByClassId(ObjectId classId)
         {
             return await _teams
-                .Find(t => classIdToName.Keys.Contains(t.AssociatedClass))
+                .Find(t => t.AssociatedClass == classId)
                 .ToListAsync();
         }
 

--- a/CS Project Manager/Services/TeamService.cs
+++ b/CS Project Manager/Services/TeamService.cs
@@ -2,8 +2,8 @@
 * Prologue
 Created By: Isabel Loney
 Date Created: 2/25/25
-Last Revised By: Anakha Krishna
-Date Revised: 3/2/25
+Last Revised By: Isabel Loney
+Date Revised: 4/10/25
 Purpose: Provides data access methods for team-related operations in the MongoDB database
 
 Preconditions: MongoDB setup, Teams table exists, Team model defined


### PR DESCRIPTION
- Fixed problem with Requirement stack breaking when trying to get null members (particular issue with Team 24)
- Ability to add a class from the account edit page
  - The text input will always be prioritized, so the dropdown select only applies changes when the text field is completely empty
  - Cannot create classes that already exist
  - Discussion Board is created for new classes
  - Automatically adds the student to the class
- Ability to add a team from the account edit page
  - Made it a completely new section since associating a class with it was going to be complicated
  - Cannot create teams that already exist for the selected class
  - Cannot create a new team if you are already in a team for that class
  - Automatically adds the student to the team
  - Discussion Board is created for new teams
- Ongoing battle with ModelState
  - I HAVE TO BIND THESE PROPERTIES IDKKK WHAT TO DOOO
  - You'll notice that I'm manually removing all these ModelState errors 
    - PLEASE let me know if there's a solution
 
NOTE:
- I made this branch based off of Isabel's `iloney-register-fixes` before her PR merged, so it includes her commits in this PR...not sure if that's an issue. If so, mention in comments