### PR TITLE
JW Meeting Minutes Page

### DIFF
--- a/CS Project Manager/Models/MeetingMinutes.cs
+++ b/CS Project Manager/Models/MeetingMinutes.cs
@@ -1,0 +1,28 @@
+/*
+* Prologue
+Created By: Jackson Wunderlich
+Date Created: 4/13/25
+Last Revised By: ackson Wunderlich
+Date Revised: 4/13/25
+Purpose: model to handle calendar items in database
+*/
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using System.ComponentModel.DataAnnotations;
+
+namespace CS_Project_Manager.Models 
+{
+    public class MeetingMinutes // creates meeting minutes class that passes in object id, notes, and associated meeting id
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public ObjectId Id { get; set; } // ObjectId identifier in Mongo
+
+        [Required]
+        public required string Notes { get; set; } // Notes for the given meeting
+ 
+        [BsonElement("AssocMeetingId")]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public ObjectId AssocMeetingId { get; set; } // Associated meeting ObjectId with notes
+    }
+}

--- a/CS Project Manager/Models/MeetingMinutes.cs
+++ b/CS Project Manager/Models/MeetingMinutes.cs
@@ -4,7 +4,7 @@ Created By: Jackson Wunderlich
 Date Created: 4/13/25
 Last Revised By: ackson Wunderlich
 Date Revised: 4/13/25
-Purpose: model to handle calendar items in database
+Purpose: model to handle minutes items in database
 */
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
@@ -23,6 +23,6 @@ namespace CS_Project_Manager.Models
  
         [BsonElement("AssocMeetingId")]
         [BsonRepresentation(BsonType.ObjectId)]
-        public ObjectId AssocMeetingId { get; set; } // Associated meeting ObjectId with notes
+        public ObjectId AssocMeetingId { get; set; } // Associated meeting ObjectId
     }
 }

--- a/CS Project Manager/Pages/Brainstorm.cshtml
+++ b/CS Project Manager/Pages/Brainstorm.cshtml
@@ -1,5 +1,8 @@
 @page
 @model CS_Project_Manager.Pages.BrainstormModel
+@{
+    ViewData["Title"] = "Brainstorm Board";
+}
 
 <a href="/RequirementsStack?projectId=@Model.ProjectId" class="btn btn-primary" style="position: absolute; top: 10px; right: 10px;">Back to Requirement Stack</a>
 

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -171,9 +171,13 @@
                             @foreach (var item in Model.TeamCalendarItems)
                             {
                                 <li>
-                                    <a href="javascript:void(0)" onclick="openDialog('@item.EventName', '@Model.ConvertToCentralTime(item.StartDateTime).ToString("yyyy-MM-ddTHH:mm")', '@Model.ConvertToCentralTime(item.EndDateTime).ToString("yyyy-MM-ddTHH:mm")', '@item.Notes', '@item.Id')">
-                                        @item.EventName: @Model.ConvertToCentralTime(item.StartDateTime).ToString()
-                                    </a>
+                                    <div style="padding:5px">
+                                        <a href="javascript:void(0)" onclick="openDialog('@item.EventName', '@Model.ConvertToCentralTime(item.StartDateTime).ToString("yyyy-MM-ddTHH:mm")', '@Model.ConvertToCentralTime(item.EndDateTime).ToString("yyyy-MM-ddTHH:mm")', '@item.Notes', '@item.Id')">
+                                            @item.EventName: @Model.ConvertToCentralTime(item.StartDateTime).ToString()
+                                        </a>
+                                        <br />
+                                        <a asp-page="/MeetingMinutes" asp-route-meetingId="@item.Id">Edit Meeting Minutes</a>
+                                    </div>
                                 </li>
                             }
                         </ul>

--- a/CS Project Manager/Pages/DiscussionBoard.cshtml
+++ b/CS Project Manager/Pages/DiscussionBoard.cshtml
@@ -1,6 +1,8 @@
 ﻿@page
 @model CS_Project_Manager.Pages.DiscussionBoardModel
 @{
+    ViewData["Title"] = "Discussion Board";
+
     <h2>@Model.BoardName Discussion Board</h2>
 
     <a asp-page="/NewPost" asp-route-boardId="@Model.BoardId" class="btn btn-primary">New Post</a>

--- a/CS Project Manager/Pages/DiscussionPost.cshtml
+++ b/CS Project Manager/Pages/DiscussionPost.cshtml
@@ -4,6 +4,8 @@
 @using System.Security.Claims
 @model CS_Project_Manager.Pages.DiscussionPostModel
 @{
+    ViewData["Title"] = "Discussion Post";
+
     <div class="container">
         <!-- Main Post -->
         <div class="post">

--- a/CS Project Manager/Pages/MeetingMinutes.cshtml
+++ b/CS Project Manager/Pages/MeetingMinutes.cshtml
@@ -1,0 +1,19 @@
+@page
+@model CS_Project_Manager.Pages.MeetingMinutesModel
+@{
+    ViewData["Title"] = "Meeting Minutes";
+}
+
+<h2>Meeting Minutes - @Model.MeetingName</h2>
+
+<form method="post">
+    <input type="hidden" name="MeetingId" value="@Model.MeetingId" />
+    <textarea name="MeetingNotes" value="@Model.MeetingNotes" style="width:100%;height:400px">@Model.MeetingNotes</textarea>
+    <br>
+    <button type="submit" asp-page-handler="Update" asp-route-id="@Model.AssocMinutes.Id" asp-route-meetingId="@Model.MeetingId" class="btn btn-primary mt-3">Update</button>
+    <!--<button type="submit" asp-page-handler="Export" class="btn btn-primary mt-3">Export</button>-->
+</form>
+<br>
+<form method="get" asp-page="/Dashboard">
+    <button type="submit" class="btn btn-primary">Back</button>
+</form>

--- a/CS Project Manager/Pages/MeetingMinutes.cshtml
+++ b/CS Project Manager/Pages/MeetingMinutes.cshtml
@@ -11,7 +11,6 @@
     <textarea name="MeetingNotes" value="@Model.MeetingNotes" style="width:100%;height:400px">@Model.MeetingNotes</textarea>
     <br>
     <button type="submit" asp-page-handler="Update" asp-route-id="@Model.AssocMinutes.Id" asp-route-meetingId="@Model.MeetingId" class="btn btn-primary mt-3">Update</button>
-    <!--<button type="submit" asp-page-handler="Export" class="btn btn-primary mt-3">Export</button>-->
 </form>
 <br>
 <form method="get" asp-page="/Dashboard">

--- a/CS Project Manager/Pages/MeetingMinutes.cshtml.cs
+++ b/CS Project Manager/Pages/MeetingMinutes.cshtml.cs
@@ -1,0 +1,108 @@
+/*
+ * Prologue
+Created By: Jackson Wunderlich
+Date Created: 4/13/25
+Last Revised By: Jackson Wunderlich
+Date Revised: 4/13/25
+Purpose: allows users to take notes for a meeting and save them to the database
+Preconditions: MongoDBService, CalendarService, MeetingMinutes Service, instances properly initialized and injected; MeetingMinutes model must be correctly defined
+Postconditions: Users can update meeting minutes for a given meeting
+Error and exceptions: ArgumentNullException (required field empty), FormatException (invalid data input)
+Side effects: N/A
+Invariants: _calendarService and _meetingMinutesService fields are always initialized with a valid instance
+Other faults: N/A
+*/
+
+using CS_Project_Manager.Models;
+using CS_Project_Manager.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using MongoDB.Bson;
+
+namespace CS_Project_Manager.Pages
+{
+    public class MeetingMinutesModel : PageModel
+    {
+        private readonly CalendarService _calendarService;
+        private readonly MeetingMinutesService _meetingMinutesService;
+
+        // bound properties for necessary variables
+        [BindProperty(SupportsGet = true)]
+        public ObjectId MeetingId { get; set; }
+
+        [BindProperty]
+        public MeetingMinutes AssocMinutes { get; set; } = new MeetingMinutes { Notes = "" };
+
+        [BindProperty]
+        public string MeetingNotes { get; set; }
+
+        [BindProperty]
+        public string MeetingName { get; set; }
+
+        public MeetingMinutesModel(CalendarService calendarService, MeetingMinutesService meetingMinutesService)
+        {
+            _calendarService = calendarService;
+            _meetingMinutesService = meetingMinutesService;
+        }
+
+        public async Task OnGetAsync(ObjectId meetingId)
+        {
+            // gets the current meeting and its corresponding minutes
+            var foundMinutes = await _meetingMinutesService.GetMinutesByMeetingIdAsync(meetingId);
+            var meeting = await _calendarService.GetCalendarItemByIdAsync(meetingId);
+            if (foundMinutes == null)
+            {
+                // if no minutes are found, create a new minutes object and add it to the database
+                var newMinutes = new MeetingMinutes { Notes = "", AssocMeetingId = meetingId };
+                await _meetingMinutesService.AddMinutesAsync(newMinutes);
+                foundMinutes = await _meetingMinutesService.GetMinutesByMeetingIdAsync(meetingId);
+            }
+            // sets bound properties to minutes values
+            AssocMinutes = foundMinutes;
+            MeetingNotes = AssocMinutes.Notes;
+            MeetingName = meeting.EventName;
+            MeetingId = meetingId;
+
+        }
+
+        // updates a minutes item
+        public async Task<IActionResult> OnPostUpdateAsync(ObjectId id, ObjectId meetingId)
+        {
+            var existingMinutes = await _meetingMinutesService.GetMinutesByIdAsync(id);
+            if (existingMinutes == null)
+            {
+                return NotFound();
+            }
+            // sets the notes to the updated notes changed by the user
+            existingMinutes.Notes = MeetingNotes;
+            
+            await _meetingMinutesService.UpdateMinutesAsync(existingMinutes);
+
+            return RedirectToPage(new { meetingId });
+        }
+
+        // exports minutes to a text document
+        /*
+        public async Task<IActionResult> OnPostExportAsync()
+        {
+            if (string.IsNullOrWhiteSpace(MeetingNotes))
+            {
+                MeetingNotes = "No minutes found!";
+            }
+
+            using (var stream = new MemoryStream())
+            using (var writer = new StreamWriter(stream))
+            {
+                // writes MeetingNotes content to a new text document
+                await writer.WriteAsync(MeetingNotes);
+                await writer.FlushAsync();
+                stream.Position = 0;
+
+                string fileName = "MeetingMinutes" + MeetingName + ".txt";
+
+                return File(stream.ToArray(), "text/plain", fileName);
+            }
+        }
+        */
+    }
+}

--- a/CS Project Manager/Pages/MeetingMinutes.cshtml.cs
+++ b/CS Project Manager/Pages/MeetingMinutes.cshtml.cs
@@ -47,6 +47,10 @@ namespace CS_Project_Manager.Pages
 
         public async Task OnGetAsync(ObjectId meetingId)
         {
+            if (meetingId == ObjectId.Parse(null))
+            {
+                throw new ArgumentException("Invalid project ID");
+            }
             // gets the current meeting and its corresponding minutes
             var foundMinutes = await _meetingMinutesService.GetMinutesByMeetingIdAsync(meetingId);
             var meeting = await _calendarService.GetCalendarItemByIdAsync(meetingId);

--- a/CS Project Manager/Pages/MeetingMinutes.cshtml.cs
+++ b/CS Project Manager/Pages/MeetingMinutes.cshtml.cs
@@ -81,8 +81,7 @@ namespace CS_Project_Manager.Pages
             return RedirectToPage(new { meetingId });
         }
 
-        // exports minutes to a text document
-        /*
+        // exports minutes to a text document (currently not functional)
         public async Task<IActionResult> OnPostExportAsync()
         {
             if (string.IsNullOrWhiteSpace(MeetingNotes))
@@ -103,6 +102,5 @@ namespace CS_Project_Manager.Pages
                 return File(stream.ToArray(), "text/plain", fileName);
             }
         }
-        */
     }
 }

--- a/CS Project Manager/Pages/MeetingMinutes.cshtml.cs
+++ b/CS Project Manager/Pages/MeetingMinutes.cshtml.cs
@@ -47,10 +47,6 @@ namespace CS_Project_Manager.Pages
 
         public async Task OnGetAsync(ObjectId meetingId)
         {
-            if (meetingId == ObjectId.Parse(null))
-            {
-                throw new ArgumentException("Invalid project ID");
-            }
             // gets the current meeting and its corresponding minutes
             var foundMinutes = await _meetingMinutesService.GetMinutesByMeetingIdAsync(meetingId);
             var meeting = await _calendarService.GetCalendarItemByIdAsync(meetingId);

--- a/CS Project Manager/Pages/RequirementsStack.cshtml
+++ b/CS Project Manager/Pages/RequirementsStack.cshtml
@@ -1,5 +1,8 @@
 @page
 @model CS_Project_Manager.Pages.RequirementsStackModel
+@{
+    ViewData["Title"] = "Requirements Stack";
+}
 
 <h2>Requirements Stack</h2>
 

--- a/CS Project Manager/Pages/RequirementsStack.cshtml.cs
+++ b/CS Project Manager/Pages/RequirementsStack.cshtml.cs
@@ -151,9 +151,7 @@ namespace CS_Project_Manager.Pages
                 .ToList();
             return RedirectToPage(new { projectId = projectId.ToString() });
         }
-        //toggle requirements as complete
-
-
+        
         // Remove a requirement
         public async Task<IActionResult> OnPostRemoveAsync(ObjectId id, ObjectId projectId)
         {
@@ -168,6 +166,7 @@ namespace CS_Project_Manager.Pages
                 .ToList();
             return RedirectToPage(new { projectId = projectId.ToString() });
         }
+
         // Export requirements to Excel
         public async Task<IActionResult> OnPostExportAsync(ObjectId projectId)
         {
@@ -229,6 +228,8 @@ namespace CS_Project_Manager.Pages
                 }
             }
         }
+
+        //toggle requirements as complete
         public async Task<IActionResult> OnPostToggleCompleteAsync(string id, string projectId)
         {
             if (!ObjectId.TryParse(id, out ObjectId requirementId))

--- a/CS Project Manager/Pages/SelectDiscussionBoard.cshtml
+++ b/CS Project Manager/Pages/SelectDiscussionBoard.cshtml
@@ -1,6 +1,7 @@
 ﻿@page
 @model CS_Project_Manager.Pages.SelectDiscussionBoardModel
 @{
+    ViewData["Title"] = "Discussion Boards";
 }
 
 <h2>My Discussion Boards</h2>

--- a/CS Project Manager/Pages/Todo.cshtml
+++ b/CS Project Manager/Pages/Todo.cshtml
@@ -1,5 +1,8 @@
 @page
 @model CS_Project_Manager.Pages.TodoModel
+@{
+    ViewData["Title"] = "To-do Lists";
+}
 
 <h2>To-do List</h2>
 

--- a/CS Project Manager/Program.cs
+++ b/CS Project Manager/Program.cs
@@ -77,6 +77,7 @@ builder.Services.AddScoped<CalendarService>();
 builder.Services.AddScoped<DiscussionBoardService>();
 builder.Services.AddScoped<DiscussionPostService>();
 builder.Services.AddScoped<UserAvailabilityService>();
+builder.Services.AddScoped<MeetingMinutesService>();
 
 var app = builder.Build(); // Build app from configured builder
 

--- a/CS Project Manager/Services/CalendarService.cs
+++ b/CS Project Manager/Services/CalendarService.cs
@@ -22,12 +22,10 @@ namespace CS_Project_Manager.Services
     public class CalendarService
     {
         private readonly IMongoCollection<CalendarItem> _calendarItems;
-        private readonly IMongoCollection<UserAvailability> _userAvailability;
 
         public CalendarService(MongoDBService mongoDBService)
         {
             _calendarItems = mongoDBService.GetCollection<CalendarItem>("CalendarItems");
-            _userAvailability = mongoDBService.GetCollection<UserAvailability>("UserAvailabilityItems");
         }
 
         // Adds a new calendar item

--- a/CS Project Manager/Services/MeetingMinutesService.cs
+++ b/CS Project Manager/Services/MeetingMinutesService.cs
@@ -1,0 +1,50 @@
+/*
+* Prologue
+Created By: Jackson Wunderlich
+Date Created: 4/13/25
+Last Revised By: Jackson Wunderlich
+Date Revised: 4/13/25
+Purpose: Provides data access methods for meeting minutes operations in the database
+Preconditions: MongoDB setup, MeetingMinutes table exists, MeetingMinutes model defined
+Postconditions: new MeetingMinutes items can be added, items can be updated and removed
+Error and exceptions: MongoDB.Driver.MongoException (thrown if there is an issue with the MongoDB connection or operations)
+Side effects: N/A
+Invariants: _minutesItems collection is always initialized with the "MeetingMinutes" collection from the MongoDB database
+Other faults: N/A
+*/
+
+using CS_Project_Manager.Models;
+using MongoDB.Driver;
+using MongoDB.Bson;
+
+namespace CS_Project_Manager.Services
+{
+    public class MeetingMinutesService
+    {
+        private readonly IMongoCollection<MeetingMinutes> _minutesItems;
+
+        public MeetingMinutesService(MongoDBService mongoDBService)
+        {
+            _minutesItems = mongoDBService.GetCollection<MeetingMinutes>("MeetingMinutes");
+        }
+
+        // Adds a new calendar item
+        public async Task AddMinutesAsync(MeetingMinutes newMinutesItem) =>
+            await _minutesItems.InsertOneAsync(newMinutesItem);
+
+        // Gets a calendar item by its ObjectId
+        public async Task<MeetingMinutes?> GetCalendarItemByIdAsync(ObjectId id) =>
+            await _minutesItems.Find(m => m.Id == id).FirstOrDefaultAsync();
+
+        // Removes a calendar item by its ObjectId
+        public async Task RemoveCalendarItemAsync(ObjectId id) =>
+            await _minutesItems.DeleteOneAsync(c => c.Id == id);
+
+        // updates a minutes item
+        public async Task UpdateCalendarItemAsync(MeetingMinutes updatedMinutes)
+        {
+            var filter = Builders<MeetingMinutes>.Filter.Eq(m => m.Id, updatedMinutes.Id);
+            await _minutesItems.ReplaceOneAsync(filter, updatedMinutes);
+        }
+    }
+}

--- a/CS Project Manager/Services/MeetingMinutesService.cs
+++ b/CS Project Manager/Services/MeetingMinutesService.cs
@@ -28,20 +28,24 @@ namespace CS_Project_Manager.Services
             _minutesItems = mongoDBService.GetCollection<MeetingMinutes>("MeetingMinutes");
         }
 
-        // Adds a new calendar item
+        // Adds a new meeting minutes item
         public async Task AddMinutesAsync(MeetingMinutes newMinutesItem) =>
             await _minutesItems.InsertOneAsync(newMinutesItem);
 
-        // Gets a calendar item by its ObjectId
-        public async Task<MeetingMinutes?> GetCalendarItemByIdAsync(ObjectId id) =>
+        // Gets a minutes item by its ObjectId
+        public async Task<MeetingMinutes?> GetMinutesByIdAsync(ObjectId id) =>
             await _minutesItems.Find(m => m.Id == id).FirstOrDefaultAsync();
 
-        // Removes a calendar item by its ObjectId
-        public async Task RemoveCalendarItemAsync(ObjectId id) =>
+        // Gets a minutes item by its meeting id
+        public async Task<MeetingMinutes?> GetMinutesByMeetingIdAsync(ObjectId meetingId) =>
+            await _minutesItems.Find(m => m.AssocMeetingId == meetingId).FirstOrDefaultAsync();
+
+        // Removes a minutes item by its ObjectId
+        public async Task RemoveMinutesAsync(ObjectId id) =>
             await _minutesItems.DeleteOneAsync(c => c.Id == id);
 
         // updates a minutes item
-        public async Task UpdateCalendarItemAsync(MeetingMinutes updatedMinutes)
+        public async Task UpdateMinutesAsync(MeetingMinutes updatedMinutes)
         {
             var filter = Builders<MeetingMinutes>.Filter.Eq(m => m.Id, updatedMinutes.Id);
             await _minutesItems.ReplaceOneAsync(filter, updatedMinutes);


### PR DESCRIPTION
Added a page to take meeting minutes for a given meeting
Currently accessible from the calendar page with a link for each meeting in the event list
If no minutes are found in the database for a given meeting, a new object will automatically be created with a matching meeting ID
The back button on the page redirects to the dashboard, but this will be changed in sprint 6 once the team and project landing pages are set up