### PR TITLE
[S6] Meeting refinement: deleting, UI updates, further date validations

### DIFF
--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -163,24 +163,38 @@
                 </form>
             </div>
             <div class="col-md-6">
+
                 <h2>Event List</h2>
                 <div id="EventList">
                     @if (Model.TeamCalendarItems.Count > 0)
                     {
-                        <ul>
-                            @foreach (var item in Model.TeamCalendarItems)
-                            {
-                                <li>
-                                    <div style="padding:5px">
-                                        <a href="javascript:void(0)" onclick="openDialog('@item.EventName', '@Model.ConvertToCentralTime(item.StartDateTime).ToString("yyyy-MM-ddTHH:mm")', '@Model.ConvertToCentralTime(item.EndDateTime).ToString("yyyy-MM-ddTHH:mm")', '@item.Notes', '@item.Id')">
-                                            @item.EventName: @Model.ConvertToCentralTime(item.StartDateTime).ToString()
-                                        </a>
-                                        <br />
-                                        <a asp-page="/MeetingMinutes" asp-route-meetingId="@item.Id">Edit Meeting Minutes</a>
-                                    </div>
-                                </li>
-                            }
-                        </ul>
+                        <table style="width: 150%;">
+                            <thead>
+                                <tr>
+                                    <th style="width: 40%;">Event Name</th>
+                                    <th style="width: 40%;">Date</th>
+                                    <th style="width: 70%;">Meeting Minutes</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var item in Model.TeamCalendarItems)
+                                {
+                                    <tr>
+                                        <td>
+                                            <a href="javascript:void(0)" onclick="openDialog('@item.EventName', '@Model.ConvertToCentralTime(item.StartDateTime).ToString("yyyy-MM-ddTHH:mm")', '@Model.ConvertToCentralTime(item.EndDateTime).ToString("yyyy-MM-ddTHH:mm")', '@item.Notes', '@item.Id')">
+                                                @item.EventName
+                                            </a>
+                                        </td>
+                                        <td>
+                                            @Model.ConvertToCentralTime(item.StartDateTime).ToString()
+                                        </td>
+                                        <td>
+                                            <a asp-page="/MeetingMinutes" asp-route-meetingId="@item.Id">Edit Meeting Minutes</a>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
                     }
                     else
                     {
@@ -188,6 +202,7 @@
                     }
                 </div>
                 <button onclick="openDialog()">Add Meeting</button>
+
             </div>
         </div>
 

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -169,12 +169,12 @@
                     @if (Model.TeamCalendarItems.Count > 0)
                     {
                         var sortedItems = Model.TeamCalendarItems.Where(item => item.EndDateTime > DateTime.UtcNow).OrderBy(item => item.StartDateTime).ToList();
-                        <table style="width: 150%;">
+                        <table style="width: 100%;">
                             <thead>
                                 <tr>
-                                    <th style="width: 40%;">Event Name</th>
-                                    <th style="width: 40%;">Start Date</th>
-                                    <th style="width: 70%;">Meeting Minutes</th>
+                                    <th style="width: 30%;">Event Name</th>
+                                    <th style="width: 30%;">Start Date</th>
+                                    <th style="width: 40%;">Meeting Minutes</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -217,12 +217,12 @@
                     @if (Model.TeamCalendarItems.Count > 0)
                     {
                         var pastMeetings = Model.TeamCalendarItems.Where(item => item.EndDateTime < DateTime.UtcNow).OrderBy(item => item.StartDateTime).ToList();
-                        <table style="width: 150%;">
+                        <table style="width: 100%;">
                             <thead>
                                 <tr>
-                                    <th style="width: 40%;">Event Name</th>
-                                    <th style="width: 40%;">Start Date</th>
-                                    <th style="width: 70%;">Meeting Minutes</th>
+                                    <th style="width: 30%;">Event Name</th>
+                                    <th style="width: 30%;">Start Date</th>
+                                    <th style="width: 40%;">Meeting Minutes</th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -354,8 +354,14 @@
     function validateForm() {
         var startTime = document.getElementById('startTime').value;
         var endTime = document.getElementById('endTime').value;
+        var currentTime = new Date().toISOString();
+
         if (new Date(startTime) >= new Date(endTime)) {
             alert('End Time must be later than Start Time.');
+            return false;
+        }
+        if (new Date(startTime) < new Date(currentTime) || new Date(endTime) < new Date(currentTime)) {
+            alert('Start Time and End Time must be later than the current UTC time.');
             return false;
         }
         return true;

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -168,6 +168,7 @@
                 <div id="EventList">
                     @if (Model.TeamCalendarItems.Count > 0)
                     {
+                        var sortedItems = Model.TeamCalendarItems.OrderBy(item => item.StartDateTime).ToList();
                         <table style="width: 150%;">
                             <thead>
                                 <tr>
@@ -177,7 +178,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                @foreach (var item in Model.TeamCalendarItems)
+                                @foreach (var item in sortedItems)
                                 {
                                     <tr>
                                         <td>

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -192,6 +192,13 @@
                                         <td>
                                             <a asp-page="/MeetingMinutes" asp-route-meetingId="@item.Id">Edit Meeting Minutes</a>
                                         </td>
+                                        <td>
+                                            <form method="post" asp-page-handler="DeleteCalendarItem">
+                                                <input type="hidden" name="teamId" value="@Model.TeamId" />
+                                                <input type="hidden" name="calendarItemId" value="@item.Id"/>
+                                                <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                                            </form>
+                                        </td>
                                     </tr>
                                 }
                             </tbody>
@@ -203,7 +210,7 @@
                     }
                 </div>
                 <br />
-                <button onclick="openDialog()">Add Meeting</button>
+                <button onclick="openDialog()" class="btn btn-primary">Add Meeting</button>
                 <br />
                 <h2>Past Meetings</h2>
                 <div id="PastMeetings">

--- a/CS Project Manager/Pages/Calendar.cshtml
+++ b/CS Project Manager/Pages/Calendar.cshtml
@@ -164,16 +164,16 @@
             </div>
             <div class="col-md-6">
 
-                <h2>Event List</h2>
+                <h2>Upcoming & Ongoing Events</h2>
                 <div id="EventList">
                     @if (Model.TeamCalendarItems.Count > 0)
                     {
-                        var sortedItems = Model.TeamCalendarItems.OrderBy(item => item.StartDateTime).ToList();
+                        var sortedItems = Model.TeamCalendarItems.Where(item => item.EndDateTime > DateTime.UtcNow).OrderBy(item => item.StartDateTime).ToList();
                         <table style="width: 150%;">
                             <thead>
                                 <tr>
                                     <th style="width: 40%;">Event Name</th>
-                                    <th style="width: 40%;">Date</th>
+                                    <th style="width: 40%;">Start Date</th>
                                     <th style="width: 70%;">Meeting Minutes</th>
                                 </tr>
                             </thead>
@@ -202,8 +202,47 @@
                         <p>No scheduled events!</p>
                     }
                 </div>
+                <br />
                 <button onclick="openDialog()">Add Meeting</button>
-
+                <br />
+                <h2>Past Meetings</h2>
+                <div id="PastMeetings">
+                    @if (Model.TeamCalendarItems.Count > 0)
+                    {
+                        var pastMeetings = Model.TeamCalendarItems.Where(item => item.EndDateTime < DateTime.UtcNow).OrderBy(item => item.StartDateTime).ToList();
+                        <table style="width: 150%;">
+                            <thead>
+                                <tr>
+                                    <th style="width: 40%;">Event Name</th>
+                                    <th style="width: 40%;">Start Date</th>
+                                    <th style="width: 70%;">Meeting Minutes</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var item in pastMeetings)
+                                {
+                                    <tr>
+                                        <td>
+                                            <a href="javascript:void(0)" onclick="openDialog('@item.EventName', '@Model.ConvertToCentralTime(item.StartDateTime).ToString("yyyy-MM-ddTHH:mm")', '@Model.ConvertToCentralTime(item.EndDateTime).ToString("yyyy-MM-ddTHH:mm")', '@item.Notes', '@item.Id', true)">
+                                                @item.EventName
+                                            </a>
+                                        </td>
+                                        <td>
+                                            @Model.ConvertToCentralTime(item.StartDateTime).ToString()
+                                        </td>
+                                        <td>
+                                            <a asp-page="/MeetingMinutes" asp-route-meetingId="@item.Id">Edit Meeting Minutes</a>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                    else
+                    {
+                        <p>No past meetings!</p>
+                    }
+                </div>
             </div>
         </div>
 
@@ -229,8 +268,8 @@
                     <textarea id="notes" name="NewCalendarItem.Notes"></textarea>
                 </div>
                 <div>
-                    <button type="submit">Confirm</button>
-                    <button type="button" onclick="closeDialog()">Cancel</button>
+                    <button type="submit" id="confirmButton">Confirm</button>
+                    <button type="button" id="cancelButton" onclick="closeDialog()">Cancel</button>
                 </div>
             </form>
         </div>
@@ -352,12 +391,30 @@
         document.getElementById('availabilityForm').submit();
     }
 
-    function openDialog(eventName = '', startTime = '', endTime = '', notes = '', id = '') {
+
+    function openDialog(eventName = '', startTime = '', endTime = '', notes = '', id = '', readOnly = false) {
         document.getElementById('meetingName').value = eventName;
         document.getElementById('startTime').value = startTime;
         document.getElementById('endTime').value = endTime;
         document.getElementById('notes').value = notes;
         document.getElementById('calendarItemId').value = id;
+
+        if (readOnly) {
+            document.getElementById('meetingName').setAttribute('readonly', true);
+            document.getElementById('startTime').setAttribute('readonly', true);
+            document.getElementById('endTime').setAttribute('readonly', true);
+            document.getElementById('notes').setAttribute('readonly', true);
+            document.getElementById('confirmButton').style.display = 'none';
+            document.getElementById('cancelButton').textContent = 'Close';
+        } else {
+            document.getElementById('meetingName').removeAttribute('readonly');
+            document.getElementById('startTime').removeAttribute('readonly');
+            document.getElementById('endTime').removeAttribute('readonly');
+            document.getElementById('notes').removeAttribute('readonly');
+            document.getElementById('confirmButton').style.display = 'inline-block';
+            document.getElementById('cancelButton').textContent = 'Cancel';
+        }
+
         document.getElementById('addMeetingDialog').style.display = 'block';
         document.getElementById('dialogOverlay').style.display = 'block';
     }
@@ -376,8 +433,8 @@
             alert('End Time must be later than Start Time.');
             return false;
         }
-        if (new Date(startTime) < new Date(currentTime) || new Date(endTime) < new Date(currentTime)) {
-            alert('Start Time and End Time must be later than the current UTC time.');
+        if (new Date(endTime) < new Date(currentTime)) {
+            alert('End Time must be later than the current UTC time.');
             return false;
         }
         return true;


### PR DESCRIPTION
Ignore the branch name; loggers will be a separate PR

- Can't set EndDateTime to a date in the past when creating or editing a meeting
- Upcoming & Ongoing events section
  - Date, event name, and meeting minutes columns
  - Events are considered upcoming or ongoing if EndDateTime is greater than DateTime.UtcNow
  - Events are ordered by date
- Past meetings section
  - Past meetings are ones where the EndDateTime is less than DateTime.UtcNow
  - The dialog box for the meeting information is readonly if a meeting is from the past
- Ability to delete a meeting
  - Deletes the associated meeting minutes if they exist
  - Cannot delete past meetings