### PR TITLE
S[6] - Ability to assign tags to a todo item and filter by said tags + bug fixes

### DIFF
--- a/CS Project Manager/Models/TodoItem.cs
+++ b/CS Project Manager/Models/TodoItem.cs
@@ -2,8 +2,8 @@
 * Prologue
 Created By: Anakha Krishna
 Date Created: 3/1/25
-Last Revised By: Anakha Krishna - comments
-Date Revised: 4/12/25
+Last Revised By: Dylan Sailors - support for tags
+Date Revised: 4/27/25
 Purpose: model to handle todo list items 
 */
 using MongoDB.Bson;
@@ -28,6 +28,7 @@ namespace CS_Project_Manager.Models
         [BsonElement("AssocTeamId")]
         [BsonRepresentation(BsonType.ObjectId)]
         public ObjectId AssocTeamId { get; set; } // Team associated with item if team item
+        public string Tag { get; set; } = "No tag"; // Tag associated with todo item
     }
 
 }

--- a/CS Project Manager/Pages/RequirementsStack.cshtml
+++ b/CS Project Manager/Pages/RequirementsStack.cshtml
@@ -289,5 +289,43 @@
                 $(this).siblings('.text-danger').show();
             }
         });
+
+        // Validate numeric inputs to ensure they're positive
+        $('input[type="number"]').on('input', function() {
+            // Skip progress inputs which can be 0
+            if (!$(this).hasClass('progress-input')) {
+                var value = parseInt($(this).val());
+                if (value <= 0) {
+                    $(this).val(''); // Clear invalid value
+                }
+            }
+        });
+
+        // For progress inputs specifically
+        $('.progress-input').on('input', function() {
+            var value = parseInt($(this).val());
+            if (value < 0) {
+                $(this).val(0);
+            } else if (value > 100) {
+                $(this).val(100);
+            }
+        });
+
+        // Check Sprint input specifically
+        $('.sprint-input').on('input', function() {
+            var value = parseInt($(this).val());
+            if (value < 1) {
+                $(this).val(''); // Clear invalid value
+                // Also handle disabling related UI elements
+                var index = $(this).data('index');
+                var progressInput = $('.progress-input[data-index="' + index + '"]');
+                var completeButton = progressInput.closest('td').next().find('.complete-button');
+                progressInput.prop('disabled', true);
+                progressInput.val(0);
+                progressInput.trigger('input');
+                completeButton.prop('disabled', true);
+                progressInput.siblings('.text-danger').show();
+            }
+        });
     });
 </script>

--- a/CS Project Manager/Pages/RequirementsStack.cshtml
+++ b/CS Project Manager/Pages/RequirementsStack.cshtml
@@ -23,17 +23,16 @@
         <tbody>
             <tr>
                 <td>
-                    <input asp-for="NewRequirement.RequirementID" class="form-control" />
+                    <input asp-for="NewRequirement.RequirementID" class="form-control" type="number" min="1"/>
                     <span asp-validation-for="NewRequirement.RequirementID" class="text-danger"></span>
                 </td>
                 <td>
                     <input asp-for="NewRequirement.Description" class="form-control" />
                     <span asp-validation-for="NewRequirement.Description" class="text-danger"></span>
                 </td>
-                <td><input asp-for="NewRequirement.StoryPoints" class="form-control" /></td>
-                <td><input asp-for="NewRequirement.Priority" class="form-control" /></td>
-                <td><input asp-for="NewRequirement.SprintNo" class="form-control" /></td>
-
+                <td><input asp-for="NewRequirement.StoryPoints" class="form-control" type="number" min="1" /></td>
+                <td><input asp-for="NewRequirement.Priority" class="form-control" type="number" min="1" /></td>
+                <td><input asp-for="NewRequirement.SprintNo" class="form-control" type="number" min="1" /></td>
                 <td>
                     <select asp-for="NewRequirement.Assignees" class="form-control assignedUsers" multiple="multiple">
                         @foreach (var member in Model.TeamMembers)
@@ -130,17 +129,16 @@
                 <tr>
                     <input type="hidden" asp-for="Requirements[i].Id" />
                     <td>
-                        <input asp-for="Requirements[i].RequirementID" class="form-control" />
+                        <input asp-for="Requirements[i].RequirementID" class="form-control" type="number" min="1" />
                         <span asp-validation-for="Requirements[i].RequirementID" class="text-danger"></span>
                     </td>
                     <td>
                         <input asp-for="Requirements[i].Description" class="form-control" />
                         <span asp-validation-for="Requirements[i].Description" class="text-danger"></span>
                     </td>
-                    <td><input asp-for="Requirements[i].StoryPoints" class="form-control" /></td>
-                    <td><input asp-for="Requirements[i].Priority" class="form-control" /></td>
-                    <td><input asp-for="Requirements[i].SprintNo" class="form-control sprint-input" data-index="@i" /></td>
-
+                    <td><input asp-for="Requirements[i].StoryPoints" class="form-control" type="number" min="1" /></td>
+                    <td><input asp-for="Requirements[i].Priority" class="form-control" type="number" min="1" /></td>
+                    <td><input asp-for="Requirements[i].SprintNo" class="form-control sprint-input" data-index="@i" type="number" min="1" /></td>
                     <td>
                         <select asp-for="Requirements[i].Assignees" class="form-control assignedUsers" multiple="multiple">
                             @foreach (var member in Model.TeamMembers)

--- a/CS Project Manager/Pages/RequirementsStack.cshtml
+++ b/CS Project Manager/Pages/RequirementsStack.cshtml
@@ -292,11 +292,10 @@
 
         // Validate numeric inputs to ensure they're positive
         $('input[type="number"]').on('input', function() {
-            // Skip progress inputs which can be 0
             if (!$(this).hasClass('progress-input')) {
                 var value = parseInt($(this).val());
                 if (value <= 0) {
-                    $(this).val(''); // Clear invalid value
+                    $(this).val('');
                 }
             }
         });
@@ -315,8 +314,7 @@
         $('.sprint-input').on('input', function() {
             var value = parseInt($(this).val());
             if (value < 1) {
-                $(this).val(''); // Clear invalid value
-                // Also handle disabling related UI elements
+                $(this).val('');
                 var index = $(this).data('index');
                 var progressInput = $('.progress-input[data-index="' + index + '"]');
                 var completeButton = progressInput.closest('td').next().find('.complete-button');

--- a/CS Project Manager/Pages/Todo.cshtml
+++ b/CS Project Manager/Pages/Todo.cshtml
@@ -13,6 +13,7 @@
             <tr>
                 <th>Name</th>
                 <th>Team Task?</th>
+                <th>Tag</th>
                 <th></th>
             </tr>
         </thead>
@@ -23,6 +24,17 @@
                     <span class="text-danger" asp-validation-for="NewTodo.ItemName"></span>
                 </td>
                 <td><input type="checkbox" asp-for="NewTodo.IsTeamItem" /></td>
+                <td>
+                    <select asp-for="NewTodo.Tag" class="form-control">
+                        <option value="No tag">No tag chosen</option>
+                        <option value="General">General</option>
+                        <option value="Code">Code</option>
+                        <option value="Documentation">Documentation</option>
+                        <option value="Brainstorm">Brainstorm</option>
+                        <option value="Bug Fix">Bug Fix</option>
+                        <option value="Other">Other</option>
+                    </select>
+                </td>
                 <td><button type="submit" asp-page-handler="Add" class="btn btn-primary">Add To-do</button></td>
             </tr>
         </tbody>
@@ -34,10 +46,28 @@
 <div class="row">
     <div class="col-md-6">
         <h3>Personal To-do List</h3>
+        <form method="post" asp-page-handler="Filter" class="mb-3">
+            <div class="form-group row">
+                <label class="col-sm-2 col-form-label">Filter by:</label>
+                <div class="col-sm-6">
+                    <select asp-for="PersonalTagFilter" class="form-control">
+                        @foreach (var tag in Model.TagOptions)
+                        {
+                            <option value="@tag">@(tag == "No tag" ? "No tag chosen" : tag)</option>
+                        }
+                    </select>
+                </div>
+                <div class="col-sm-4">
+                    <button type="submit" class="btn btn-secondary">Apply Filter</button>
+                </div>
+            </div>
+        </form>
+
         <table class="table">
             <thead>
                 <tr>
                     <th>Name</th>
+                    <th>Tag</th>
                     <th>Completed</th>
                     <th>Remove Task</th>
                 </tr>
@@ -48,9 +78,23 @@
                     <tr>
                         <td>@todo.ItemName</td>
                         <td>
+                            <form method="post" asp-page-handler="UpdateTag">
+                                <input type="hidden" name="id" value="@todo.Id" />
+                                <select name="tag" class="form-control" onchange="this.form.submit()">
+                                    <option value="No tag" selected="@(todo.Tag == "No tag")">No tag chosen</option>
+                                    <option value="General" selected="@(todo.Tag == "General")">General</option>
+                                    <option value="Code" selected="@(todo.Tag == "Code")">Code</option>
+                                    <option value="Documentation" selected="@(todo.Tag == "Documentation")">Documentation</option>
+                                    <option value="Brainstorm" selected="@(todo.Tag == "Brainstorm")">Brainstorm</option>
+                                    <option value="Bug Fix" selected="@(todo.Tag == "Bug Fix")">Bug Fix</option>
+                                    <option value="Other" selected="@(todo.Tag == "Other")">Other</option>
+                                </select>
+                            </form>
+                        </td>
+                        <td>
                             <form method="post" asp-page-handler="ToggleComplete">
                                 <input type="hidden" name="id" value="@todo.Id" />
-                                <input type="checkbox" name="isComplete" value="true" onchange="this.form.submit()" @(todo.ItemComplete ? "checked" : "") />
+                                <input type="checkbox" name="isComplete" value="true" onchange="this.form.submit()" checked="@todo.ItemComplete" />
                             </form>
                         </td>
                         <td>
@@ -67,10 +111,27 @@
 
     <div class="col-md-6">
         <h3>Team To-do List</h3>
+        <form method="post" asp-page-handler="Filter" class="mb-3">
+            <div class="form-group row">
+                <label class="col-sm-2 col-form-label">Filter by:</label>
+                <div class="col-sm-6">
+                    <select asp-for="TeamTagFilter" class="form-control">
+                        @foreach (var tag in Model.TagOptions)
+                        {
+                            <option value="@tag">@(tag == "No tag" ? "No tag chosen" : tag)</option>
+                        }
+                    </select>
+                </div>
+                <div class="col-sm-4">
+                    <button type="submit" class="btn btn-secondary">Apply Filter</button>
+                </div>
+            </div>
+        </form>
         <table class="table">
             <thead>
                 <tr>
                     <th>Name</th>
+                    <th>Tag</th>
                     <th>Completed</th>
                     <th>Remove Task</th>
                 </tr>
@@ -81,9 +142,23 @@
                     <tr>
                         <td>@todo.ItemName</td>
                         <td>
+                            <form method="post" asp-page-handler="UpdateTag">
+                                <input type="hidden" name="id" value="@todo.Id" />
+                                <select name="tag" class="form-control" onchange="this.form.submit()">
+                                    <option value="No tag" selected="@(todo.Tag == "No tag")">No tag chosen</option>
+                                    <option value="General" selected="@(todo.Tag == "General")">General</option>
+                                    <option value="Code" selected="@(todo.Tag == "Code")">Code</option>
+                                    <option value="Documentation" selected="@(todo.Tag == "Documentation")">Documentation</option>
+                                    <option value="Brainstorm" selected="@(todo.Tag == "Brainstorm")">Brainstorm</option>
+                                    <option value="Bug Fix" selected="@(todo.Tag == "Bug Fix")">Bug Fix</option>
+                                    <option value="Other" selected="@(todo.Tag == "Other")">Other</option>
+                                </select>
+                            </form>
+                        </td>
+                        <td>
                             <form method="post" asp-page-handler="ToggleComplete">
                                 <input type="hidden" name="id" value="@todo.Id" />
-                                <input type="checkbox" name="isComplete" value="true" onchange="this.form.submit()" @(todo.ItemComplete ? "checked" : "") />
+                                <input type="checkbox" name="isComplete" value="true" onchange="this.form.submit()" checked="@todo.ItemComplete" />
                             </form>
                         </td>
                         <td>
@@ -128,18 +203,18 @@
 
                     <td>
                         <div style="display: flex; gap: 10px;">
-                        <button type="submit" asp-page-handler="UpdateReq"
-                                asp-route-id="@Model.Requirements[i].Id"
-                                asp-route-projectId="@Model.Requirements[i].AssocProjectId"
-                                class="btn btn-warning">
-                            Update
-                        </button>
-                        <button type="submit" asp-page-handler="RemoveReq"
-                                asp-route-id="@Model.Requirements[i].Id"
-                                asp-route-projectId="@Model.Requirements[i].AssocProjectId"
-                                class="btn btn-danger">
-                            Remove
-                        </button>
+                            <button type="submit" asp-page-handler="UpdateReq"
+                                    asp-route-id="@Model.Requirements[i].Id"
+                                    asp-route-projectId="@Model.Requirements[i].AssocProjectId"
+                                    class="btn btn-warning">
+                                Update
+                            </button>
+                            <button type="submit" asp-page-handler="RemoveReq"
+                                    asp-route-id="@Model.Requirements[i].Id"
+                                    asp-route-projectId="@Model.Requirements[i].AssocProjectId"
+                                    class="btn btn-danger">
+                                Remove
+                            </button>
                         </div>
                     </td>
                 </tr>

--- a/CS Project Manager/Pages/Todo.cshtml
+++ b/CS Project Manager/Pages/Todo.cshtml
@@ -25,7 +25,7 @@
                 </td>
                 <td><input type="checkbox" asp-for="NewTodo.IsTeamItem" /></td>
                 <td>
-                    <select asp-for="NewTodo.Tag" class="form-control">
+                    <select asp-for="NewTodo.Tag" class="form-control" style="min-width: 130px;">
                         <option value="No tag">No tag chosen</option>
                         <option value="General">General</option>
                         <option value="Code">Code</option>
@@ -46,11 +46,12 @@
 <div class="row">
     <div class="col-md-6">
         <h3>Personal To-do List</h3>
-        <form method="post" asp-page-handler="Filter" class="mb-3">
+        <form method="post" asp-page-handler="FilterPersonal" class="mb-3">
+            <input type="hidden" asp-for="TeamTagFilter" />
             <div class="form-group row">
                 <label class="col-sm-2 col-form-label">Filter by:</label>
                 <div class="col-sm-6">
-                    <select asp-for="PersonalTagFilter" class="form-control">
+                    <select asp-for="PersonalTagFilter" class="form-control" style="min-width: 130px;">
                         @foreach (var tag in Model.TagOptions)
                         {
                             <option value="@tag">@(tag == "No tag" ? "No tag chosen" : tag)</option>
@@ -80,7 +81,9 @@
                         <td>
                             <form method="post" asp-page-handler="UpdateTag">
                                 <input type="hidden" name="id" value="@todo.Id" />
-                                <select name="tag" class="form-control" onchange="this.form.submit()">
+                                <input type="hidden" asp-for="PersonalTagFilter" />
+                                <input type="hidden" asp-for="TeamTagFilter" />
+                                <select name="tag" class="form-control" style="min-width: 130px;" onchange="this.form.submit()">
                                     <option value="No tag" selected="@(todo.Tag == "No tag")">No tag chosen</option>
                                     <option value="General" selected="@(todo.Tag == "General")">General</option>
                                     <option value="Code" selected="@(todo.Tag == "Code")">Code</option>
@@ -94,12 +97,16 @@
                         <td>
                             <form method="post" asp-page-handler="ToggleComplete">
                                 <input type="hidden" name="id" value="@todo.Id" />
+                                <input type="hidden" asp-for="PersonalTagFilter" />
+                                <input type="hidden" asp-for="TeamTagFilter" />
                                 <input type="checkbox" name="isComplete" value="true" onchange="this.form.submit()" checked="@todo.ItemComplete" />
                             </form>
                         </td>
                         <td>
                             <form method="post" asp-page-handler="Remove">
                                 <input type="hidden" name="id" value="@todo.Id" />
+                                <input type="hidden" asp-for="PersonalTagFilter" />
+                                <input type="hidden" asp-for="TeamTagFilter" />
                                 <button type="submit" class="btn btn-danger">Remove</button>
                             </form>
                         </td>
@@ -111,11 +118,12 @@
 
     <div class="col-md-6">
         <h3>Team To-do List</h3>
-        <form method="post" asp-page-handler="Filter" class="mb-3">
+        <form method="post" asp-page-handler="FilterTeam" class="mb-3">
+            <input type="hidden" asp-for="PersonalTagFilter" />
             <div class="form-group row">
                 <label class="col-sm-2 col-form-label">Filter by:</label>
                 <div class="col-sm-6">
-                    <select asp-for="TeamTagFilter" class="form-control">
+                    <select asp-for="TeamTagFilter" class="form-control" style="min-width: 130px;">
                         @foreach (var tag in Model.TagOptions)
                         {
                             <option value="@tag">@(tag == "No tag" ? "No tag chosen" : tag)</option>
@@ -144,7 +152,9 @@
                         <td>
                             <form method="post" asp-page-handler="UpdateTag">
                                 <input type="hidden" name="id" value="@todo.Id" />
-                                <select name="tag" class="form-control" onchange="this.form.submit()">
+                                <input type="hidden" asp-for="PersonalTagFilter" />
+                                <input type="hidden" asp-for="TeamTagFilter" />
+                                <select name="tag" class="form-control" style="min-width: 135px;" onchange="this.form.submit()">
                                     <option value="No tag" selected="@(todo.Tag == "No tag")">No tag chosen</option>
                                     <option value="General" selected="@(todo.Tag == "General")">General</option>
                                     <option value="Code" selected="@(todo.Tag == "Code")">Code</option>
@@ -158,12 +168,16 @@
                         <td>
                             <form method="post" asp-page-handler="ToggleComplete">
                                 <input type="hidden" name="id" value="@todo.Id" />
+                                <input type="hidden" asp-for="PersonalTagFilter" />
+                                <input type="hidden" asp-for="TeamTagFilter" />
                                 <input type="checkbox" name="isComplete" value="true" onchange="this.form.submit()" checked="@todo.ItemComplete" />
                             </form>
                         </td>
                         <td>
                             <form method="post" asp-page-handler="Remove">
                                 <input type="hidden" name="id" value="@todo.Id" />
+                                <input type="hidden" asp-for="PersonalTagFilter" />
+                                <input type="hidden" asp-for="TeamTagFilter" />
                                 <button type="submit" class="btn btn-danger">Remove</button>
                             </form>
                         </td>
@@ -177,6 +191,8 @@
 <h2>Personal Requirements</h2>
 
 <form method="post">
+    <input type="hidden" asp-for="PersonalTagFilter" />
+    <input type="hidden" asp-for="TeamTagFilter" />
     <table class="table">
         <thead>
             <tr>

--- a/CS Project Manager/Pages/Todo.cshtml.cs
+++ b/CS Project Manager/Pages/Todo.cshtml.cs
@@ -149,7 +149,7 @@ namespace CS_Project_Manager.Pages
 
             await _todoService.AddTodoAsync(NewTodo);
 
-            return RedirectToPage();
+            return RedirectToPage(new { personalTagFilter = PersonalTagFilter, teamTagFilter = TeamTagFilter });
         }
 
         // Toggle the completion status of a task
@@ -157,7 +157,7 @@ namespace CS_Project_Manager.Pages
         {
             if (!ObjectId.TryParse(id, out ObjectId objectId))
             {
-                return RedirectToPage();
+                return RedirectToPage(new { personalTagFilter = PersonalTagFilter, teamTagFilter = TeamTagFilter });
             }
 
             var todo = await _todoService.GetTodoByIdAsync(objectId);
@@ -167,7 +167,7 @@ namespace CS_Project_Manager.Pages
                 await _todoService.UpdateTodoAsync(todo);
             }
 
-            return RedirectToPage();
+            return RedirectToPage(new { personalTagFilter = PersonalTagFilter, teamTagFilter = TeamTagFilter });
         }
 
         // Remove a task
@@ -175,12 +175,11 @@ namespace CS_Project_Manager.Pages
         {
             if (!ObjectId.TryParse(id, out ObjectId objectId))
             {
-                return RedirectToPage();
+                return RedirectToPage(new { personalTagFilter = PersonalTagFilter, teamTagFilter = TeamTagFilter });
             }
 
             await _todoService.RemoveTodoAsync(objectId);
-
-            return RedirectToPage();
+            return RedirectToPage(new { personalTagFilter = PersonalTagFilter, teamTagFilter = TeamTagFilter });
         }
 
         // Update a task's tag
@@ -188,7 +187,7 @@ namespace CS_Project_Manager.Pages
         {
             if (!ObjectId.TryParse(id, out ObjectId objectId))
             {
-                return RedirectToPage();
+                return RedirectToPage(new { personalTagFilter = PersonalTagFilter, teamTagFilter = TeamTagFilter });
             }
             var todo = await _todoService.GetTodoByIdAsync(objectId);
             if (todo != null)
@@ -196,7 +195,19 @@ namespace CS_Project_Manager.Pages
                 todo.Tag = tag;
                 await _todoService.UpdateTodoAsync(todo);
             }
-            return RedirectToPage();
+            return RedirectToPage(new { personalTagFilter = PersonalTagFilter, teamTagFilter = TeamTagFilter });
+        }
+
+        // Filter personal tasks only
+        public IActionResult OnPostFilterPersonalAsync()
+        {
+            return RedirectToPage(new { personalTagFilter = PersonalTagFilter, teamTagFilter = TeamTagFilter });
+        }
+
+        // Filter team tasks only
+        public IActionResult OnPostFilterTeamAsync()
+        {
+            return RedirectToPage(new { personalTagFilter = PersonalTagFilter, teamTagFilter = TeamTagFilter });
         }
 
         // Handles filtering by tag
@@ -231,7 +242,7 @@ namespace CS_Project_Manager.Pages
             Requirements = (await _requirementService.GetRequirementsByUserIdAsync(UserId))
                 .OrderBy(r => r.RequirementID ?? int.MaxValue)
                 .ToList();
-            return RedirectToPage();
+            return RedirectToPage(new { personalTagFilter = PersonalTagFilter, teamTagFilter = TeamTagFilter });
         }
 
         public async Task<IActionResult> OnPostRemoveReqAsync(ObjectId id, ObjectId projectId)
@@ -245,7 +256,7 @@ namespace CS_Project_Manager.Pages
             Requirements = (await _requirementService.GetRequirementsByUserIdAsync(UserId))
                 .OrderBy(r => r.RequirementID ?? int.MaxValue)
                 .ToList();
-            return RedirectToPage();
+            return RedirectToPage(new { personalTagFilter = PersonalTagFilter, teamTagFilter = TeamTagFilter });
         }
     }
 }


### PR DESCRIPTION
- added feature to add tags (the list of tags were the first things that came to mind. if you have other tag ideas lmk and i'll add it)
- added feature to filter by said tags
- all tags start off as "no tag"
- filter starts off as "All" showing all the todo items
- when changing or assigning tags to already added todo items, the second you select a tag, it is updated since there's no "update" button for it to wait on
- individual filters for personal and team todo lists
     - only one can be applied at a time tho (lmk if you want that changed)

bug fix:
- requirements stack no longer allows for you to even type in a negative value or even click the arrow to go negative

Account used for implementing and testing:
     EECS 582
     Team 24
     email: dylanlol@ku.edu
     password: dylanlol